### PR TITLE
fix(typing): 后台回前台 typing 卡死 — 落库清 typing + 回前台 reset (#10)

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKTypingManager.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKTypingManager.m
@@ -45,6 +45,37 @@ static WKTypingManager *_instance = nil;
     return _instance;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        // 监听 conversation-sync 落库通知：后台期间 bot 回复经同步直写 DB 绕过
+        // onRecvMessages，导致 typing 卡死，这里收到通知后清除对应 channel 的 typing。
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(onConversationSyncedNewMessages:)
+                                                     name:@"WKConversationSyncedNewMessages"
+                                                   object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)onConversationSyncedNewMessages:(NSNotification *)notification {
+    WKChannel *channel = notification.object;
+    if (![channel isKindOfClass:[WKChannel class]]) {
+        return;
+    }
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self removeTypingByChannel:channel newMessage:nil];
+        });
+    } else {
+        [self removeTypingByChannel:channel newMessage:nil];
+    }
+}
+
 - (NSMutableDictionary<WKChannel *,WKMessage *> *)channelTypingMessageDict {
     if(!_channelTypingMessageDict) {
         _channelTypingMessageDict = [[NSMutableDictionary alloc] init];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -2408,6 +2408,11 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
     if(status == WKConnected) { // 如果已连接，则重新请求消息
         __weak typeof(self) weakSelf = self;
         [self pullup:^(bool more) {
+            // 重连/回前台拉取消息后，若当前 channel 仍残留 typing（后台期间 bot 回复经
+            // conversation-sync 直写 DB 绕过了 onRecvMessages 的清除路径），显式清掉。
+            if([[WKTypingManager shared] hasTyping:weakSelf.channel]) {
+                [[WKTypingManager shared] removeTypingByChannel:weakSelf.channel newMessage:nil];
+            }
             WKMessageModel *localLastMsg = [weakSelf.dataProvider lastMessage];
             if(!localLastMsg) {
                 return;

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -58,6 +58,7 @@
 #import "WKTypingMessageCell.h"
 #import "WKTypingContent.h"
 #import "WKOnlineStatusManager.h"
+#import "WKTypingManager.h"
 #import "WKHistorySplitTipCell.h"
 #import "WKHistorySplitTipContent.h"
 #import "WKMergeForwardContent.h"
@@ -766,6 +767,13 @@ static WKApp *_instance;
         // 解决网页端异常断开后iOS端仍显示"网页端在线"的问题
         [WKOnlineStatusManager shared].needUpdate = YES;
         [[WKOnlineStatusManager shared] requestUpdateChannelOnlineStatusIfNeed];
+    }
+
+    // 回前台时无任何 typing reset 机制，叠加后台期间 bot 回复经 conversation-sync 绕过
+    // typing 清除路径，会导致 typing indicator 永久卡死。这里统一清掉所有残留 typing；
+    // 若对方确实仍在输入，下一个 typing CMD 到达后会自然恢复。
+    for (WKMessage *typingMsg in [[WKTypingManager shared] getAllTypingMessages]) {
+        [[WKTypingManager shared] removeTypingByChannel:typingMsg.channel newMessage:nil];
     }
     // 连接
     if([[WKSDK shared] connectionManager].connectStatus == WKDisconnected  && [WKApp shared].isLogined) {

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConversationManager.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConversationManager.m
@@ -299,6 +299,16 @@
             [self callOnConversationUpdateDelegates:conversations];
         }
 
+        // 后台期间 bot 回复经 conversation-sync 直写 DB，绕过 onRecvMessages 的 typing 清除路径，
+        // 导致 typing indicator 永久卡死。落库后对有新消息(recents)的 channel 发通知，
+        // 由 WKTypingManager 监听并清除对应 channel 的 typing（observer 内部会切回主线程）。
+        for (WKSyncConversationModel *syncConversationModel in syncConversations) {
+            if(syncConversationModel.recents.count > 0) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"WKConversationSyncedNewMessages"
+                                                                    object:syncConversationModel.conversation.channel];
+            }
+        }
+
         CFAbsoluteTime syncElapsed = (CFAbsoluteTimeGetCurrent() - syncStart) * 1000;
         if (syncElapsed > 30) {
             NSLog(@"[ANR-Trace] handleSyncConversation took %.0fms (background), syncCount=%lu, msgCount=%lu", syncElapsed, (unsigned long)syncConversations.count, (unsigned long)messages.count);


### PR DESCRIPTION
## 问题

octo-ios#10：群聊中 App 切后台、bot 回复完成后切回前台，typing indicator 永久卡死、消息看似不刷新。

## 根因

typing 清除的唯一可靠路径在 `onRecvMessages`（push 路径）。后台期间 bot 回复经 conversation-sync 直写 DB，绕过该路径 → typing 永不清。叠加回前台无任何 typing reset 机制。

## 改动（Fix-1 + Fix-2）

### Fix-1：conversation-sync 落库后清 typing
- `WKConversationManager handleSyncConversation:` 写库后，对有 `recents` 的 channel 发 `WKConversationSyncedNewMessages` 通知。
- `WKTypingManager` 监听该通知 → `removeTypingByChannel:`（统一切到主线程执行）。
- `WKMessageListView onConnectStatus:WKConnected` 的 pullup 回调里，若当前 channel 仍有 typing 显式清掉。

### Fix-2：回前台 reset 全部 typing
- `WKApp appDidBecomeActive:` 遍历 `getAllTypingMessages` 清除所有 typing。若对方仍在输入，下一个 typing CMD 到达后自然恢复。

## 副作用

回前台瞬间 typing 会被清掉，若对方确实还在输入会闪一下，可接受。改动均在主线程，不引入新的线程安全问题。Fix-3/4 留后续独立 PR。

## 验证

1. 群聊让 bot 回复，App 切后台等回复完成 → 切回前台：typing 立即消失，消息正常显示。
2. 正常前台聊天：typing 显示/消失不受影响。

Fixes #10
