### PR TITLE
fix(typing): Fix-3 background timer + dict locking, Fix-4 syncCompleted refresh hook

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKTypingManager.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKTypingManager.m
@@ -23,6 +23,13 @@
 
 @property(nonatomic,strong) NSMutableDictionary<WKChannel*,dispatch_block_t> *cancelTypingBlockDict; // 取消输入中状态的的block
 
+/**
+ *  dictLock 用于保护 channelTypingMessageDict / cancelTypingBlockDict 的读写。
+ *  超时 timer 现已挂在后台队列(见 addTypingByMessage)，回调会从后台线程访问这两个
+ *  dict，无锁访问 NSMutableDictionary 在多群并发 typing 时会崩溃，故统一加锁。
+ */
+@property(nonatomic,strong) NSObject *dictLock;
+
 @property(nonatomic,assign) BOOL offTyping; // 是否关闭typing
 @end
 
@@ -39,15 +46,20 @@ static WKTypingManager *_instance = nil;
 }
 
 +(instancetype) shared{
-    if (_instance == nil) {
-        _instance = [[super alloc]init];
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _instance = [[super alloc] init];
+    });
     return _instance;
 }
 
 - (instancetype)init {
     self = [super init];
     if (self) {
+        // 提前初始化共享状态，保证后台 timer 回调与主线程访问看到的是同一份 dict / lock。
+        _channelTypingMessageDict = [[NSMutableDictionary alloc] init];
+        _cancelTypingBlockDict = [[NSMutableDictionary alloc] init];
+        _dictLock = [[NSObject alloc] init];
         // 监听 conversation-sync 落库通知：后台期间 bot 回复经同步直写 DB 绕过
         // onRecvMessages，导致 typing 卡死，这里收到通知后清除对应 channel 的 typing。
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -90,6 +102,13 @@ static WKTypingManager *_instance = nil;
     return _cancelTypingBlockDict;
 }
 
+- (NSObject *)dictLock {
+    if (_dictLock == nil) {
+        _dictLock = [[NSObject alloc] init];
+    }
+    return _dictLock;
+}
+
 - (NSLock *)delegateLock {
     if (_delegateLock == nil) {
         _delegateLock = [[NSLock alloc] init];
@@ -116,7 +135,10 @@ static WKTypingManager *_instance = nil;
 }
 
 -(BOOL) hasTyping:(WKChannel*)channel {
-    WKMessage *message = self.channelTypingMessageDict[channel];
+    WKMessage *message = nil;
+    @synchronized (self.dictLock) {
+        message = self.channelTypingMessageDict[channel];
+    }
     if(message) {
         return true;
     }
@@ -124,31 +146,42 @@ static WKTypingManager *_instance = nil;
 }
 
 - (void)addTypingByMessage:(WKMessage *)typingMessage {
-    
+
 //    WKMessage *typingMessage = [self convertMessageToTypingMessage:message];
     if( [typingMessage.fromUid isEqualToString:[WKApp shared].loginInfo.uid]) {
         return;
     }
-    
+
     WKChannel *channel = typingMessage.channel;
-    WKMessage *oldTypingMessage = self.channelTypingMessageDict[channel];
-    self.channelTypingMessageDict[channel] = typingMessage;
-    
-    dispatch_block_t cancelTypingBlock = self.cancelTypingBlockDict[channel];
-     if(cancelTypingBlock) {
-         dispatch_block_cancel(cancelTypingBlock);
-     }
-     __weak typeof(self) weakSelf = self;
-     cancelTypingBlock = dispatch_block_create(0, ^{
-         [weakSelf removeTypingByChannel:channel newMessage:nil];
-     });
-     self.cancelTypingBlockDict[channel] = cancelTypingBlock;
-     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(8 * NSEC_PER_SEC)), dispatch_get_main_queue(),cancelTypingBlock);
-    if(!oldTypingMessage) {
+    __weak typeof(self) weakSelf = self;
+    BOOL isNewTyping = NO;
+    @synchronized (self.dictLock) {
+        WKMessage *oldTypingMessage = self.channelTypingMessageDict[channel];
+        self.channelTypingMessageDict[channel] = typingMessage;
+        isNewTyping = (oldTypingMessage == nil);
+
+        dispatch_block_t oldCancelBlock = self.cancelTypingBlockDict[channel];
+        if(oldCancelBlock) {
+            dispatch_block_cancel(oldCancelBlock);
+        }
+        // timer 改挂后台队列，避免 App 进后台时 main queue 挂起导致 8s 超时冻结，
+        // 切回前台后 typing 卡死不消失。回调内按时间戳判定是否过期再清除。
+        dispatch_block_t cancelTypingBlock = dispatch_block_create(0, ^{
+            WKMessage *cur = nil;
+            @synchronized (weakSelf.dictLock) {
+                cur = weakSelf.channelTypingMessageDict[channel];
+            }
+            if (cur && ([[NSDate date] timeIntervalSince1970] - cur.timestamp >= 8.0)) {
+                [weakSelf removeTypingByChannel:channel newMessage:nil];
+            }
+        });
+        self.cancelTypingBlockDict[channel] = cancelTypingBlock;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(8 * NSEC_PER_SEC)),
+                       dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), cancelTypingBlock);
+    }
+    if(isNewTyping) {
         [self callTypingAddDelegate:typingMessage];
     }
-     
-    
 }
 
 -(WKMessage*) convertParamToTypingMessage:(NSDictionary*)param {
@@ -181,20 +214,32 @@ static WKTypingManager *_instance = nil;
 }
 
 - (NSArray<WKMessage *> *)getAllTypingMessages {
-    
-    return [self.channelTypingMessageDict allValues];
+    @synchronized (self.dictLock) {
+        return [self.channelTypingMessageDict allValues];
+    }
 }
 
 - (WKMessage *)getTypingMessage:(WKChannel *)channel {
-    
-    return self.channelTypingMessageDict[channel];
+    @synchronized (self.dictLock) {
+        return self.channelTypingMessageDict[channel];
+    }
 }
 
 
 - (void)removeTypingByChannel:(WKChannel *)channel newMessage:(WKMessage*)newMessage{
-    WKMessage *message = [self.channelTypingMessageDict objectForKey:channel];
+    WKMessage *message = nil;
+    @synchronized (self.dictLock) {
+        message = [self.channelTypingMessageDict objectForKey:channel];
+        if(message) {
+            [self.channelTypingMessageDict removeObjectForKey:channel];
+            dispatch_block_t cancelBlock = self.cancelTypingBlockDict[channel];
+            if(cancelBlock) {
+                dispatch_block_cancel(cancelBlock);
+                [self.cancelTypingBlockDict removeObjectForKey:channel];
+            }
+        }
+    }
     if(message) {
-        [self.channelTypingMessageDict removeObjectForKey:channel];
         [self callTypingRemoveDelegate:message newMessage:newMessage];
     }
 }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -22,7 +22,7 @@
 #import "WKMessageCell.h"
 #import "WKMultipleSelectToHereButton.h"
 #import <SDWebImage/SDWebImage.h>
-@interface WKMessageListView ()<UITableViewDelegate,UITableViewDataSource,WKConversationTableViewDelegate,WKChannelManagerDelegate,WKChatManagerDelegate,WKReactionManagerDelegate,WKConnectionManagerDelegate,WKTypingManagerDelegate,WKReminderManagerDelegate>
+@interface WKMessageListView ()<UITableViewDelegate,UITableViewDataSource,WKConversationTableViewDelegate,WKChannelManagerDelegate,WKChatManagerDelegate,WKReactionManagerDelegate,WKConnectionManagerDelegate,WKTypingManagerDelegate,WKReminderManagerDelegate,WKConversationManagerDelegate>
 
 @property(nonatomic,strong) UIViewPropertyAnimator *headerViewsAnimator;
 @property(nonatomic,assign) BOOL didManuallyStoppedTableViewDecelerating;
@@ -118,6 +118,7 @@
     [[WKSDK shared].chatManager addDelegate:self]; // 消息监听
     [[WKSDK shared].reactionManager addDelegate:self]; // 回应监听
     [[WKSDK shared].connectionManager addDelegate:self]; // 连接状态监听
+    [[WKSDK shared].conversationManager addDelegate:self]; // conversation-sync 完成监听(后台收消息切回前台补刷)
     [[WKTypingManager shared] addDelegate:self]; // 正在输入...
     [[WKReminderManager shared] addDelegate:self]; // 提醒项监听
     // 外部分享消息发送通知
@@ -131,6 +132,7 @@
     [[WKSDK shared].chatManager removeDelegate:self];
     [[WKSDK shared].reactionManager removeDelegate:self];
     [[WKSDK shared].connectionManager  removeDelegate:self];
+    [[WKSDK shared].conversationManager removeDelegate:self];
     [[WKTypingManager shared] removeDelegate:self];
     [[WKReminderManager shared] removeDelegate:self];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"WKShareExtensionMessageSent" object:nil];
@@ -2427,6 +2429,54 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
             }
         }];
     }
+}
+
+#pragma mark - WKConversationManagerDelegate
+
+// conversation-sync 完成后(SDK 已 merge 进 DB)的全量补刷钩子，对齐 Android 的
+// syncCompleted → getData(true)。App 后台期间收到的新消息经 conversation-sync 直写
+// DB，可能绕过 onRecvMessages 的增量插入；切回前台 sync 完成后，这里检查当前 channel
+// 的 DB 最后一条消息是否比 UI 显示的更新，有更新则强制补刷，避免 pullup 的 drift 兜底
+// 吞掉刷新导致新消息不显示。已由 SDK 派发回主线程，这里不再 dispatch_async。
+- (void)onConversationSyncFinished {
+    if(!self.channel) {
+        return;
+    }
+    WKMessage *dbLastMsg = [[WKSDK shared].chatManager getLastMessage:self.channel];
+    if(!dbLastMsg) {
+        return;
+    }
+    // DB 最后一条与 UI 当前最后一条一致 → 无更新，跳过。
+    if(self.lastMessage && [self.lastMessage.clientMsgNo isEqualToString:dbLastMsg.clientMsgNo]) {
+        return;
+    }
+
+    // 残留 typing 一并清掉(后台期间 bot 回复直写 DB 绕过了清除路径)。
+    if([[WKTypingManager shared] hasTyping:self.channel]) {
+        [[WKTypingManager shared] removeTypingByChannel:self.channel newMessage:nil];
+    }
+
+    __weak typeof(self) weakSelf = self;
+    if([self pullupHasMore]) {
+        // 下方还有未加载的历史分页，整页 reloadData 会破坏分页锚点，
+        // 这里只更新最后一条预览引用，让 pullup/滚动时再增量补齐。
+        [self updateLastMsgIfNeed:[[WKMessageModel alloc] initWithMessage:dbLastMsg]];
+        return;
+    }
+    // 已到底：补刷把新消息拉进 dataProvider 并刷新 UI。
+    [self pullup:^(bool more) {
+        WKMessageModel *localLastMsg = [weakSelf.dataProvider lastMessage];
+        if(!localLastMsg) {
+            return;
+        }
+        if(weakSelf.lastMessage && [weakSelf.lastMessage.clientMsgNo isEqualToString:localLastMsg.clientMsgNo]) {
+            return;
+        }
+        WKMessage *newLastMsg = [[WKSDK shared].chatManager getLastMessage:weakSelf.channel];
+        if(newLastMsg) {
+            [weakSelf updateLastMsgIfNeed:[[WKMessageModel alloc] initWithMessage:newLastMsg]];
+        }
+    }];
 }
 
 #pragma mark - WKTypingManagerDelegate


### PR DESCRIPTION
Second batch of fixes for #10 (PR #12 shipped Fix-1 + Fix-2). This PR does Fix-3 and Fix-4.

## Fix-3 — typing 8s timeout timer → background queue + dict locking

`WKTypingManager` previously scheduled the 8s typing-timeout `dispatch_after` on the **main queue**. When the app is backgrounded the main queue is suspended, so the timer freezes and stale typing indicators stick around after returning to the foreground.

- Guard `channelTypingMessageDict` / `cancelTypingBlockDict` with a dedicated `@synchronized` lock (prerequisite — the background timer callback must not touch an unlocked `NSMutableDictionary`, which crashes under concurrent multi-channel typing).
- Move the 8s timer to `dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)` so it keeps firing while backgrounded.
- Timer callback re-checks the message timestamp (`now - timestamp >= 8.0`) before clearing, so a refreshed typing event isn't wrongly removed.
- `removeTypingByChannel` now also cancels and drops the pending timer block.
- `+shared` singleton switched from `if(_instance==nil)` to `dispatch_once` (per YUJ-2595).

`removeTypingByChannel`'s delegate callback (`callTypingRemoveDelegate`) already dispatches to the main thread, so firing it from the background timer is safe for UI.

## Fix-4 — iOS syncCompleted full-refresh hook

iOS lacked Android's `syncCompleted → getData(true)` equivalent. Messages received while backgrounded arrive via conversation-sync writing straight to the DB, bypassing `onRecvMessages`' incremental insert, so the open chat could miss them.

- `WKMessageListView` now adopts `WKConversationManagerDelegate` and registers/unregisters it.
- `onConversationSyncFinished` checks whether the current channel's DB last message is newer than the UI's; if so it forces a refresh (pullup when at bottom, last-message ref update otherwise), so new messages show up even when pullup's drift fallback would swallow the refresh.

## Verification
1. Background > 8s → foreground → typing auto-clears within 8s (Fix-3 background timer).
2. Receive a message while backgrounded → foreground → message list auto-refreshes (Fix-4).
3. High concurrency (many groups typing at once) does not crash (Fix-3 locking).

Part of #10

Closes #10