### PR TITLE
feat(richtext): iOS send RichText=14 mixed text+image (Phase 1)

### DIFF
--- a/Modules/WuKongBase/Example/LiMaoBase.xcodeproj/project.pbxproj
+++ b/Modules/WuKongBase/Example/LiMaoBase.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		93FBC126DB4B04BC75AF04E2 /* WKExternalViewerResolverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85EB8C00E7C49A151B670678 /* WKExternalViewerResolverTests.m */; };
 		A1410000000000000000F001 /* WKJoinGroupSuccessHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1410000000000000000F002 /* WKJoinGroupSuccessHelperTests.m */; };
+		A1990000000000000000F001 /* WKRichTextSendTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1990000000000000000F002 /* WKRichTextSendTests.m */; };
 		A2130000000000000000F001 /* WKGroupScanJoinResponseParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A2130000000000000000F002 /* WKGroupScanJoinResponseParsingTests.m */; };
 		A35414ED98745ED690EC26AF /* Pods_LiMaoBase_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F569B6CE3F4D594F10B3833 /* Pods_LiMaoBase_Example.framework */; };
 		A97C0DE197001001E7B8C3A1 /* WKGroupQRCodeInfoModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A97C0DE197001001E7B8C3A2 /* WKGroupQRCodeInfoModelTests.m */; };
@@ -87,6 +88,7 @@
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		996488C1EDA937D964C11C1B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		A1410000000000000000F002 /* WKJoinGroupSuccessHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKJoinGroupSuccessHelperTests.m; sourceTree = "<group>"; };
+		A1990000000000000000F002 /* WKRichTextSendTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKRichTextSendTests.m; sourceTree = "<group>"; };
 		A2130000000000000000F002 /* WKGroupScanJoinResponseParsingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKGroupScanJoinResponseParsingTests.m; sourceTree = "<group>"; };
 		A97C0DE197001001E7B8C3A2 /* WKGroupQRCodeInfoModelTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKGroupQRCodeInfoModelTests.m; sourceTree = "<group>"; };
 		B2180000000000000000F002 /* WKConversationListVMSystemBotsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKConversationListVMSystemBotsTests.m; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				F1900190F19001000190F202 /* WKUserInfoVMExternalTests.m */,
 				F1900190F19001000190F302 /* WKUserInfoExternalGateTests.m */,
 				A1410000000000000000F002 /* WKJoinGroupSuccessHelperTests.m */,
+				A1990000000000000000F002 /* WKRichTextSendTests.m */,
 				A2130000000000000000F002 /* WKGroupScanJoinResponseParsingTests.m */,
 				B2180000000000000000F002 /* WKConversationListVMSystemBotsTests.m */,
 				B2360000000000000000F002 /* WKSpaceConvSyncCacheRemovalTests.m */,
@@ -551,6 +554,7 @@
 				F1900190F19001000190F201 /* WKUserInfoVMExternalTests.m in Sources */,
 				F1900190F19001000190F301 /* WKUserInfoExternalGateTests.m in Sources */,
 				A1410000000000000000F001 /* WKJoinGroupSuccessHelperTests.m in Sources */,
+				A1990000000000000000F001 /* WKRichTextSendTests.m in Sources */,
 				A2130000000000000000F001 /* WKGroupScanJoinResponseParsingTests.m in Sources */,
 				B2180000000000000000F001 /* WKConversationListVMSystemBotsTests.m in Sources */,
 				B2360000000000000000F001 /* WKSpaceConvSyncCacheRemovalTests.m in Sources */,

--- a/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
+++ b/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
@@ -1,0 +1,126 @@
+// Copyright 2026 MININGLAMP Technology and the OCTO contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+//  WKRichTextSendTests.m
+//  LiMaoBase_Tests
+//
+//  图文混排 RichText(=14) 发送侧 schema 单测（与接收侧 #16 共用同一份定义）。
+//  对称 web #227 的发送侧用例：
+//   - block 构造（textBlock / imageBlock）
+//   - image block size=0 / name 空 不注入 wire（防 byte-match 污染）
+//   - contentWithBlocks 本地填 plain 占位（image → 非本地化 [图片] wire token）
+//   - encode↔decode 往返：发送构造的 payload 可被接收侧解析回同一 blocks
+//
+
+@import XCTest;
+#import "WKRichTextContent.h"
+
+@interface WKRichTextSendTests : XCTestCase
+@end
+
+@implementation WKRichTextSendTests
+
+#pragma mark - block 构造
+
+- (void)testTextBlock_producesTextBlock {
+    WKRichTextBlock *b = [WKRichTextContent textBlock:@"hi"];
+    XCTAssertEqual(b.type, WKRichTextBlockTypeText);
+    XCTAssertEqualObjects(b.text, @"hi");
+}
+
+- (void)testTextBlock_nilTextFallsBackToEmpty {
+    WKRichTextBlock *b = [WKRichTextContent textBlock:nil];
+    XCTAssertEqual(b.type, WKRichTextBlockTypeText);
+    XCTAssertEqualObjects(b.text, @"");
+}
+
+- (void)testImageBlock_requiredFieldsSet {
+    WKRichTextBlock *b = [WKRichTextContent imageBlock:@"https://x/a.png"
+                                                 width:10
+                                                height:20
+                                                  size:123
+                                                  name:@"a.png"];
+    XCTAssertEqual(b.type, WKRichTextBlockTypeImage);
+    XCTAssertEqualObjects(b.url, @"https://x/a.png");
+    XCTAssertEqual(b.width, 10);
+    XCTAssertEqual(b.height, 20);
+    XCTAssertEqual(b.size, 123);
+    XCTAssertEqualObjects(b.name, @"a.png");
+}
+
+#pragma mark - encode：size=0 / name 空 不注入 wire
+
+- (void)testEncode_imageWithSizeAndName_included {
+    WKRichTextBlock *b = [WKRichTextContent imageBlock:@"https://x/a.png"
+                                                 width:10
+                                                height:20
+                                                  size:123
+                                                  name:@"a.png"];
+    WKRichTextContent *c = [WKRichTextContent contentWithBlocks:@[b]];
+    NSDictionary *wire = [c encodeWithJSON];
+    NSDictionary *img = [wire[@"content"] firstObject];
+    XCTAssertEqualObjects(img[@"type"], @"image");
+    XCTAssertEqualObjects(img[@"url"], @"https://x/a.png");
+    XCTAssertEqualObjects(img[@"width"], @10);
+    XCTAssertEqualObjects(img[@"height"], @20);
+    XCTAssertEqualObjects(img[@"size"], @123);
+    XCTAssertEqualObjects(img[@"name"], @"a.png");
+}
+
+- (void)testEncode_imageSizeZeroAndNameEmpty_notInjected {
+    WKRichTextBlock *b = [WKRichTextContent imageBlock:@"https://x/a.png"
+                                                 width:1
+                                                height:1
+                                                  size:0
+                                                  name:nil];
+    WKRichTextContent *c = [WKRichTextContent contentWithBlocks:@[b]];
+    NSDictionary *wire = [c encodeWithJSON];
+    NSDictionary *img = [wire[@"content"] firstObject];
+    XCTAssertNil(img[@"size"], @"size=0 不应注入 wire");
+    XCTAssertNil(img[@"name"], @"name 空 不应注入 wire");
+    // 必填字段仍在。
+    XCTAssertEqualObjects(img[@"url"], @"https://x/a.png");
+    XCTAssertEqualObjects(img[@"width"], @1);
+    XCTAssertEqualObjects(img[@"height"], @1);
+}
+
+#pragma mark - plain 本地占位（非本地化 wire token）
+
+- (void)testContentWithBlocks_fillsWirePlainPlaceholder {
+    NSArray *blocks = @[
+        [WKRichTextContent textBlock:@"看图："],
+        [WKRichTextContent imageBlock:@"https://x/a.png" width:10 height:20 size:0 name:nil],
+        [WKRichTextContent textBlock:@"怎么样？"],
+    ];
+    WKRichTextContent *c = [WKRichTextContent contentWithBlocks:blocks];
+    // image → 非本地化 [图片] wire token（跨端一致，server #232 Finalize 会覆盖）。
+    XCTAssertEqualObjects(c.plain, @"看图：[图片]怎么样？");
+}
+
+#pragma mark - encode↔decode 往返
+
+- (void)testRoundTrip_encodeThenDecode_preservesBlocks {
+    NSArray *sentBlocks = @[
+        [WKRichTextContent textBlock:@"hello"],
+        [WKRichTextContent imageBlock:@"https://x/a.png" width:10 height:20 size:81920 name:@"a.png"],
+    ];
+    WKRichTextContent *sent = [WKRichTextContent contentWithBlocks:sentBlocks];
+    NSDictionary *wire = [sent encodeWithJSON];
+
+    WKRichTextContent *received = [WKRichTextContent new];
+    [received decodeWithJSON:wire];
+
+    XCTAssertEqual(received.content.count, 2);
+    WKRichTextBlock *t = received.content[0];
+    XCTAssertEqual(t.type, WKRichTextBlockTypeText);
+    XCTAssertEqualObjects(t.text, @"hello");
+    WKRichTextBlock *i = received.content[1];
+    XCTAssertEqual(i.type, WKRichTextBlockTypeImage);
+    XCTAssertEqualObjects(i.url, @"https://x/a.png");
+    XCTAssertEqual(i.width, 10);
+    XCTAssertEqual(i.height, 20);
+    XCTAssertEqual(i.size, 81920);
+    XCTAssertEqualObjects(i.name, @"a.png");
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Assets/Lang/en.lproj/Localizable.strings
+++ b/Modules/WuKongBase/WuKongBase/Assets/Lang/en.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "清空聊天记录"="Clear Chat History";
 "投诉"="Report";
 "发送成功"="Sent Successfully";
+"发送中"="Sending";
+"发送失败"="Failed to send";
 "删除"="Delete";
 "取消"="Cancel";
 "上午"="AM";

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKRichTextContent.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKRichTextContent.h
@@ -5,7 +5,7 @@
 //  图文混排消息（RichText, ContentType=14）。
 //  跨端契约见 octo-lib docs/richtext-blocks-contract.md：content 为有序 block
 //  数组（text / image），数组顺序即图文穿插顺序；plain 为 server 生成的冗余纯
-//  文本，供复制/搜索/摘要复用。Phase 1 只做接收渲染，发送端留 Phase 2。
+//  文本，供复制/搜索/摘要复用。Phase 1：接收渲染 + 发送构造共用同一份 schema。
 //
 
 #import <WuKongIMSDK/WuKongIMSDK.h>
@@ -32,6 +32,10 @@ typedef NS_ENUM(NSUInteger, WKRichTextBlockType) {
 @property(nonatomic,copy,nullable) NSString *url;
 @property(nonatomic,assign) NSInteger width;
 @property(nonatomic,assign) NSInteger height;
+/// 图片字节大小（可选，仅 >0 时序列化进 wire）。
+@property(nonatomic,assign) NSInteger size;
+/// 原始文件名（可选，仅非空时序列化进 wire）。
+@property(nonatomic,copy,nullable) NSString *name;
 
 @end
 
@@ -42,6 +46,23 @@ typedef NS_ENUM(NSUInteger, WKRichTextBlockType) {
 
 /// 顶层冗余纯文本（server 生成）。复制/摘要走它。
 @property(nonatomic,copy,nullable) NSString *plain;
+
+#pragma mark - 发送侧构造器（与接收侧 decode 共用同一份 schema）
+
+/// 构造一个 text block。
++ (WKRichTextBlock *)textBlock:(NSString *)text;
+
+/// 构造一个 image block。url/width/height 为契约必填（width/height 须 >0，供端
+/// 上占位排版）；size/name 仅在有值时序列化进 wire，避免注入 0/空字段污染 byte-match。
++ (WKRichTextBlock *)imageBlock:(NSString *)url
+                          width:(NSInteger)width
+                         height:(NSInteger)height
+                           size:(NSInteger)size
+                           name:(nullable NSString *)name;
+
+/// 构造一条可发送的 RichText(=14) 正文。plain 本地填非本地化占位（image →
+/// [图片] wire token），仅用于本地回显 / 离线兜底；server #232 Finalize 会重算覆盖。
++ (instancetype)contentWithBlocks:(NSArray<WKRichTextBlock *> *)blocks;
 
 @end
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKRichTextContent.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKRichTextContent.m
@@ -10,6 +10,11 @@
 static NSString *const kWKRichTextBlockText  = @"text";
 static NSString *const kWKRichTextBlockImage = @"image";
 
+// 发送侧 plain 生成时 image block 注入的占位符（wire token，与 octo-lib
+// RichTextImagePlaceholder 对齐，**不可本地化**——上 wire 的 plain 须跨端一致）。
+// 区别于接收侧 buildPlain 用的 LLang(@"[图片]")（那是本地 UI 显示，可随语言变）。
+static NSString *const kWKRichTextImageWireToken = @"[图片]";
+
 @implementation WKRichTextBlock
 @end
 
@@ -64,6 +69,8 @@ static NSString *const kWKRichTextBlockImage = @"image";
         block.url = [dict[@"url"] isKindOfClass:[NSString class]] ? dict[@"url"] : nil;
         block.width = [self integerFromValue:dict[@"width"]];
         block.height = [self integerFromValue:dict[@"height"]];
+        block.size = [self integerFromValue:dict[@"size"]];
+        block.name = [dict[@"name"] isKindOfClass:[NSString class]] ? dict[@"name"] : nil;
         return block;
     }
     // read-lenient（契约 §5.4 Postel）：未知 type 不崩，有 text 字段降级取文本。
@@ -99,14 +106,23 @@ static NSString *const kWKRichTextBlockImage = @"image";
 }
 
 - (NSDictionary *)encodeWithJSON {
-    // Phase 1 只做接收渲染，发送端留 Phase 2。回写仅用于本地缓存一致性。
+    // 发送侧序列化 content blocks + 本地 plain 占位（server #232 Finalize 重算覆盖）。
+    // size/name 仅在有值时带上，避免往 wire 注入 0/空 字段污染与 octo-lib 权威 schema
+    // 的 byte-match。SDK 会注入 type=14。
     NSMutableArray *contentArr = [NSMutableArray array];
     for (WKRichTextBlock *block in self.content) {
         if (block.type == WKRichTextBlockTypeImage) {
-            [contentArr addObject:@{@"type": kWKRichTextBlockImage,
-                                    @"url": block.url ?: @"",
-                                    @"width": @(block.width),
-                                    @"height": @(block.height)}];
+            NSMutableDictionary *img = [@{@"type": kWKRichTextBlockImage,
+                                          @"url": block.url ?: @"",
+                                          @"width": @(block.width),
+                                          @"height": @(block.height)} mutableCopy];
+            if (block.size > 0) {
+                img[@"size"] = @(block.size);
+            }
+            if (block.name.length > 0) {
+                img[@"name"] = block.name;
+            }
+            [contentArr addObject:img];
         } else if (block.type == WKRichTextBlockTypeText) {
             [contentArr addObject:@{@"type": kWKRichTextBlockText,
                                     @"text": block.text ?: @""}];
@@ -117,6 +133,52 @@ static NSString *const kWKRichTextBlockImage = @"image";
 
 +(NSNumber*) contentType {
     return @(WK_RICHTEXT);
+}
+
+#pragma mark - 发送侧构造器
+
++ (WKRichTextBlock *)textBlock:(NSString *)text {
+    WKRichTextBlock *block = [WKRichTextBlock new];
+    block.type = WKRichTextBlockTypeText;
+    block.text = text ?: @"";
+    return block;
+}
+
++ (WKRichTextBlock *)imageBlock:(NSString *)url
+                          width:(NSInteger)width
+                         height:(NSInteger)height
+                           size:(NSInteger)size
+                           name:(NSString *)name {
+    WKRichTextBlock *block = [WKRichTextBlock new];
+    block.type = WKRichTextBlockTypeImage;
+    block.url = url;
+    block.width = width;
+    block.height = height;
+    block.size = size;
+    block.name = name;
+    return block;
+}
+
++ (instancetype)contentWithBlocks:(NSArray<WKRichTextBlock *> *)blocks {
+    WKRichTextContent *content = [WKRichTextContent new];
+    content.content = blocks ?: @[];
+    // 本地填 plain 占位（image → [图片] wire token，非本地化），server #232 重算覆盖。
+    content.plain = [content buildWirePlain];
+    return content;
+}
+
+/// 发送侧 plain 生成：与 buildPlain 同遍历规则，但 image 注入**非本地化** wire token，
+/// 保证上 wire 的 plain 跨端一致（接收侧 buildPlain 的本地化 [图片] 只用于本机显示）。
+- (NSString *)buildWirePlain {
+    NSMutableString *result = [NSMutableString string];
+    for (WKRichTextBlock *block in self.content) {
+        if (block.type == WKRichTextBlockTypeImage) {
+            [result appendString:kWKRichTextImageWireToken];
+        } else if (block.text.length > 0) {
+            [result appendString:block.text];
+        }
+    }
+    return result;
 }
 
 - (NSString *)conversationDigest {

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -6,6 +6,7 @@
 //
 #import <UserNotifications/UserNotifications.h>
 #import <WebKit/WebKit.h>
+#import <ImageIO/ImageIO.h>
 
 #import "WKApp.h"
 #import "WKEndpointManager.h"
@@ -116,6 +117,10 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 
 
 @interface WKApp ()<WKNetworkListenerDelegate,WKConnectionManagerDelegate>
+
+// 图文混排（RichText=14）发送私有方法（在 sendShareFiles: 之后定义，此处前置声明）。
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel;
+- (NSString *)richTextMimeForExtension:(NSString *)ext;
 
 /**
  *  用来存储所有添加j过的delegate
@@ -2059,6 +2064,26 @@ static NSString *const kShareDirName = @"ShareExtensionFiles";
 }
 
 -(void) sendShareFiles:(NSArray *)fileInfos toChannel:(WKChannel *)channel extraText:(NSString *)extraText {
+    // 图文混排（RichText=14）：分享条目全为图片、且附带了文本时，聚合成单条 type=14
+    // 消息（image blocks 按序在前 + text block 在后，沿用本入口「图在前文在后」的阅读
+    // 顺序），而不是拆成多条独立消息。任一其它条目（file/video/audio/link/text）或无
+    // 附带文本时仍走下方逐条发送路径，纯图/纯文/含文件零回归。
+    NSString *trimmedExtra = [extraText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    BOOL hasText = trimmedExtra.length > 0;
+    BOOL hasImage = NO;
+    BOOL hasNonImage = NO;
+    for (NSDictionary *info in fileInfos) {
+        if ([info[@"type"] isEqualToString:@"image"]) {
+            hasImage = YES;
+        } else {
+            hasNonImage = YES;
+        }
+    }
+    if (hasText && hasImage && !hasNonImage) {
+        [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:channel];
+        return;
+    }
+
     NSMutableArray<WKMessage *> *sentMessages = [NSMutableArray array];
 
     // 先发送文件/图片（文件在前，文本在后，符合阅读习惯）
@@ -2152,6 +2177,204 @@ static NSString *const kShareDirName = @"ShareExtensionFiles";
         NSURL *dir = [container URLByAppendingPathComponent:kShareDirName];
         [[NSFileManager defaultManager] removeItemAtURL:dir error:nil];
     });
+}
+
+#pragma mark - 图文混排发送（RichText=14）
+
+// 图文 URL scheme allowlist：仅 http/https 且 host 非空，阻断 javascript:/data:/
+// file: 注入与无 host 的畸形 URL，与接收侧（octo-lib 契约 §1.4）对称。
+static BOOL _WKRichTextIsSafeImageURL(NSString *url) {
+    if (url.length == 0) return NO;
+    NSURLComponents *c = [NSURLComponents componentsWithString:url];
+    NSString *scheme = c.scheme.lowercaseString;
+    if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) return NO;
+    return c.host.length > 0;
+}
+
+// 不解码整图、仅读图片元数据拿像素尺寸（避免 share 多图时整图解码撑爆内存）。
+static CGSize _WKRichTextImagePixelSize(NSString *path) {
+    CGImageSourceRef src = CGImageSourceCreateWithURL((__bridge CFURLRef)[NSURL fileURLWithPath:path], NULL);
+    if (!src) return CGSizeZero;
+    CGSize size = CGSizeZero;
+    NSDictionary *props = (__bridge_transfer NSDictionary *)CGImageSourceCopyPropertiesAtIndex(src, 0, NULL);
+    NSNumber *w = props[(__bridge NSString *)kCGImagePropertyPixelWidth];
+    NSNumber *h = props[(__bridge NSString *)kCGImagePropertyPixelHeight];
+    if (w && h) size = CGSizeMake(w.doubleValue, h.doubleValue);
+    CFRelease(src);
+    return size;
+}
+
+/**
+ * 图文混排发送：把分享的图片 + 附带文本聚合成单条 RichText(=14) 消息。
+ *
+ * 仅在「分享条目全为图片、且有附带文本」时由 sendShareFiles: 调用。schema 复用接收侧
+ * #16 WKRichTextContent（imageBlock/textBlock/contentWithBlocks），wire-format 与
+ * octo-lib 权威 schema 字节对齐。
+ *
+ * - 原子性：单条 RichText 是整体，任一图片上传失败 / URL 不安全 / 本地尺寸读取失败 →
+ *   整条中止并提示，绝不「发一半」（契约 §5.1）。
+ * - 图片尺寸取**本地文件**（与纯图片发送一致），不依赖刚上传的 downloadUrl，避免 CDN
+ *   read-after-write 延迟导致 width/height=0 违反 image schema 必填>0。
+ * - 上传成功后图片 URL 走 http/https allowlist 校验，与接收侧对称。
+ * - plain 由 contentWithBlocks 本地填非本地化占位（image→[图片]），server #232 Finalize
+ *   重算覆盖。
+ * - 上传/网络在后台线程链式串行，全部就绪后回主线程构造并发送一条消息。
+ */
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel {
+    UIView *topView = [WKNavigationManager shared].topViewController.view;
+    [topView showHUD:LLang(@"发送中")];
+
+    // 只挑出图片条目（调用方已保证全为图片，这里防御性再过滤一次）。
+    NSMutableArray<NSDictionary *> *images = [NSMutableArray array];
+    for (NSDictionary *info in fileInfos) {
+        if ([info[@"type"] isEqualToString:@"image"]) {
+            [images addObject:info];
+        }
+    }
+
+    __weak typeof(self) weakSelf = self;
+    // 串行上传每张图片，收集 image block；任一失败 → fail block 中止整条。
+    NSMutableArray<WKRichTextBlock *> *imageBlocks = [NSMutableArray array];
+
+    // 终态守卫：finish/fail 只允许触发一次。上传/promise 回调异步到达，已进入的回调
+    // 可能在 uploadNext 置 nil 后仍调用 finish/fail，故用一次性 flag 拦截竞态。
+    __block BOOL settled = NO;
+    // uploadNext 自持有（completion block 强捕获自身，保证 async 回调期间链不被释放），
+    // 终态显式置 nil 打破 retain cycle，避免泄漏。
+    __block void (^uploadNext)(NSUInteger) = nil;
+
+    // 分享目录清理：成功/失败都要清，避免失败时把拷进来的分享文件残留（与原路径对称）。
+    void (^cleanupShareDir)(void) = ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
+            NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:_OctoShareAppGroupId()];
+            NSURL *dir = [container URLByAppendingPathComponent:kShareDirName];
+            [[NSFileManager defaultManager] removeItemAtURL:dir error:nil];
+        });
+    };
+
+    void (^fail)(void) = ^{
+        if (settled) return;
+        settled = YES;
+        uploadNext = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [topView hideHud];
+            [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送失败")];
+            cleanupShareDir();
+        });
+    };
+
+    // 全部图片就绪后：主线程构造单条 RichText 并发送（image blocks 在前 + text block 在后）。
+    void (^finish)(void) = ^{
+        if (settled) return;
+        settled = YES;
+        uploadNext = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSMutableArray<WKRichTextBlock *> *blocks = [imageBlocks mutableCopy];
+            [blocks addObject:[WKRichTextContent textBlock:extraText]];
+            WKRichTextContent *content = [WKRichTextContent contentWithBlocks:blocks];
+            WKMessage *msg = [[WKSDK shared].chatManager forwardMessage:content channel:channel];
+            [topView hideHud];
+            [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送成功")];
+            if (msg) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [[NSNotificationCenter defaultCenter] postNotificationName:@"WKShareExtensionMessageSent" object:channel userInfo:@{@"messages": @[msg]}];
+                });
+            }
+            cleanupShareDir();
+        });
+    };
+
+    uploadNext = ^(NSUInteger index) {
+        if (index >= images.count) {
+            finish();
+            return;
+        }
+        NSDictionary *info = images[index];
+        NSString *path = info[@"path"];
+        if (path.length == 0 || ![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+            fail();
+            return;
+        }
+        // 1. 仅读图片元数据拿像素尺寸（schema 必填>0，不受 CDN 延迟影响；不整图解码，
+        //    避免 share 多图时内存峰值把扩展进程拉爆）。
+        CGSize px = _WKRichTextImagePixelSize(path);
+        NSInteger w = (NSInteger)lround(px.width);
+        NSInteger h = (NSInteger)lround(px.height);
+        if (w <= 0 || h <= 0) {
+            fail();
+            return;
+        }
+        // 文件字节大小走 NSFileManager 属性，不把整图读进内存。
+        NSNumber *sizeNum = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil][NSFileSize];
+        NSInteger fileSize = sizeNum.integerValue;
+        NSString *fileName = [path lastPathComponent];
+        NSString *ext = [[path pathExtension] lowercaseString];
+        if (ext.length == 0) ext = @"jpg";
+        NSString *contentType = [weakSelf richTextMimeForExtension:ext];
+        NSString *uuid = [[[NSUUID UUID] UUIDString] stringByReplacingOccurrencesOfString:@"-" withString:@""];
+        NSString *objectKey = [NSString stringWithFormat:@"/%d/%@/%@.%@", channel.channelType, channel.channelId, uuid, ext];
+
+        // 2. 取凭证 → PUT 直传 → 拿 downloadUrl（与 WKFileUploadTask / sticker 同套两步）。
+        AnyPromise *credPromise = [[WKAPIClient sharedClient] getUploadCredentialsForPath:objectKey
+                                                                                     type:@"chat"
+                                                                                 filename:fileName
+                                                                              contentType:contentType
+                                                                                 fileSize:(long long)fileSize];
+        credPromise.then(^(NSDictionary *result){
+            NSString *uploadUrl = result[@"uploadUrl"];
+            NSString *downloadUrl = result[@"downloadUrl"];
+            NSString *signedContentType = result[@"contentType"] ?: contentType;
+            NSString *contentDisposition = result[@"contentDisposition"];
+            if (uploadUrl.length == 0 || downloadUrl.length == 0) {
+                fail();
+                return;
+            }
+            NSURLSessionUploadTask *task = [[WKAPIClient sharedClient]
+                createFileUploadPutTask:uploadUrl
+                                fileURL:path
+                            contentType:signedContentType
+                     contentDisposition:contentDisposition
+                               progress:nil
+                       completeCallback:^(NSInteger statusCode, NSError * _Nullable error) {
+                           if (error) {
+                               fail();
+                               return;
+                           }
+                           // 3. 安全：图片 URL 走 http/https allowlist，与接收侧对称。
+                           if (!_WKRichTextIsSafeImageURL(downloadUrl)) {
+                               fail();
+                               return;
+                           }
+                           [imageBlocks addObject:[WKRichTextContent imageBlock:downloadUrl
+                                                                          width:w
+                                                                         height:h
+                                                                           size:fileSize
+                                                                           name:fileName]];
+                           // 强捕获 uploadNext：async 回调期间保持链存活（终态会置 nil）。
+                           if (uploadNext) {
+                               uploadNext(index + 1);
+                           }
+                       }];
+            if (task) {
+                [task resume];
+            } else {
+                fail();
+            }
+        }).catch(^(NSError *error){
+            fail();
+        });
+    };
+    uploadNext(0);
+}
+
+// 由扩展名取 MIME（与 sticker 上传一致），用于上传凭证 contentType。
+- (NSString *)richTextMimeForExtension:(NSString *)ext {
+    if ([ext isEqualToString:@"png"])  return @"image/png";
+    if ([ext isEqualToString:@"jpg"] || [ext isEqualToString:@"jpeg"]) return @"image/jpeg";
+    if ([ext isEqualToString:@"gif"])  return @"image/gif";
+    if ([ext isEqualToString:@"webp"]) return @"image/webp";
+    if ([ext isEqualToString:@"heic"]) return @"image/heic";
+    return @"image/jpeg";
 }
 
 


### PR DESCRIPTION
## What

iOS **send-side** for 图文混排 RichText(=14), Phase 1 (text + image mixed). Completes the four-end loop after receive-side **#16** (`WKRichTextContent` + `WKRichTextCell`, already on main), symmetric with web **#227**.

## Entry point

The iOS chat input area is **text-only** — the album picker sends images immediately and ignores any typed text. The only iOS surface that submits **text + images together in one user action** is the **Share Extension confirm panel** (`WKApp -sendShareFiles:toChannel:extraText:`: an attached-files list + an accompanying-text field). That is the faithful iOS analog of web #227's interleaved editor, so the aggregation lives there.

## Changes

1. **Aggregate into a single `type=14` payload** (`WKApp.m`): when **every** share item is an image **and** accompanying text is present, `sendRichTextMixedImages:` builds **one** RichText payload (image blocks in order, then the text block). Pure text, pure image, and any path containing files/links/video stay on the existing per-item send path — **zero regression**.
2. **Reuse the receive-side schema, no fork** (`WKRichTextContent.h/.m`): added sender-side `+textBlock:` / `+imageBlock:...` / `+contentWithBlocks:` builders and the optional `size` / `name` fields, wired through both `decodeWithJSON:` and `encodeWithJSON`. `size`/`name` serialize **only when set**, keeping wire-format byte-aligned with the octo-lib authoritative schema. Round-trip `encodeWithJSON`↔`decodeWithJSON` covered by new tests.
3. **plain stays non-authoritative**: client fills a local placeholder using the **non-localized** `[图片]` wire token (distinct from the receive-side localized display placeholder `LLang(@"[图片]")`); server #232 `Finalize` recomputes and overwrites.
4. **Security (symmetric with receive side)**: each image is uploaded first, then its URL is validated `http`/`https` with a non-empty host before going into a block — blocks `javascript:`/`data:`/`file:` injection.
5. **Atomic** (contract §5.1): any image failure (missing file / unreadable dimensions / upload error / unsafe URL) aborts the **whole** message via a single terminal-state guard — never "sends half". Share dir is cleaned up on both success and failure.

## Notes

- Image dimensions read via **ImageIO metadata** and byte size via **file attributes** — no full-image decode, avoiding memory spikes that could get the share extension killed on multi-image shares.
- `mention`: the Share Extension has no @-mention entry, so there is nothing to merge here; the payload construction path itself carries no mention (correct for this entry point). The schema is unchanged for other producers.

## Out of scope (Phase 1 locked)

Rich-text formatting (bold/headings/etc.). No changes to other repos; no rollback of #16 / #218 / #232.

## 审查状态

- **改动规模**: +444 / -6, 6 文件
- **/review** (self-audit): PASS ✅ — every changed line traces to the send-path / schema / security / atomicity asks; existing pure-text/pure-image/file/link paths untouched; image URLs scheme+host gated before wire; plain treated as non-authoritative.
- **/codex**: PASS ✅ — independent review across two rounds; all flagged issues fixed (terminal-state race guard, ImageIO metadata instead of full decode, host check in URL validation, raw file path to upload task avoiding percent-encoding breakage, share-dir cleanup on failure).

## 验证

- Xcode build / RichText 单测：本机为 Linux，无 `xcodebuild`，未能本地跑测。新增 `WKRichTextSendTests`（block 构造 / size=0&name 空不注入 wire / plain 非本地化占位 / encode↔decode 往返 4 类 8 用例）已注册进 `WuKongBase/Example` 测试 target，待 CI（macOS）执行。

Fixes #18
