### PR TITLE
fix(richtext): album picker no longer drops typed text (Fixes #21)

### DIFF
--- a/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
+++ b/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
@@ -124,37 +124,42 @@
     XCTAssertEqualObjects(i.name, @"a.png");
 }
 
-#pragma mark - 相册选图 footgun 守卫（输入框有文本时不丢字）
-// octo-ios#21：相册选图发图前若输入框有待发文本，须把图+文本聚合成单条 RichText(=14)，
-// 不能只发图把文字静默丢掉。下面覆盖聚合决策的全部分支（含「选图时输入框有文本」回归）。
+#pragma mark - 相册选图 footgun 守卫（输入框有文本时不丢字 + 部分发送原子性）
+// octo-ios#21：相册选图发图前若输入框有待发文本，须由图文聚合路径接管，把图+文本聚合成
+// 单条 RichText(=14)，不能只发图把文字静默丢掉。下面覆盖接管决策的全部分支。
+// 关键点：决策基于用户实际选中的图片资产数（assetCount），不看压缩结果——只要选了图且
+// 输入框有文本就接管（含压缩丢图甚至全丢的情况）。绝不能因原子性问题退回原逐条路径，
+// 否则文本会被原路径丢掉且原 loop 越界崩溃。压缩丢图的原子性在
+// sendRichTextMixedImageDatas: 内校验（imageDatas.count != assetCount → 整条失败 + 恢复
+// 草稿），属运行期行为，非纯函数。
 
 - (void)testAlbumAggregate_imagesWithText_aggregates {
-    // 回归核心：选图时输入框有文本 → 走图文聚合（修复前是只发图丢文字）。
-    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:2 pendingText:@"看这个"]);
+    // 回归核心：选图时输入框有文本 → 由聚合路径接管（修复前是只发图丢文字）。
+    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:2 pendingText:@"看这个"]);
 }
 
 - (void)testAlbumAggregate_singleImageWithText_aggregates {
-    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:1 pendingText:@"hi"]);
+    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:1 pendingText:@"hi"]);
 }
 
 - (void)testAlbumAggregate_imagesWithoutText_doesNotAggregate {
     // 纯图无文本：原逐条发送路径不动，零回归。
-    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:3 pendingText:nil]);
-    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:3 pendingText:@""]);
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:3 pendingText:nil]);
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:3 pendingText:@""]);
 }
 
 - (void)testAlbumAggregate_whitespaceOnlyText_doesNotAggregate {
-    // 仅空白文本视作无文本，不聚合（避免发出一条只含空白的多余文本块）。
-    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:1 pendingText:@"   \n\t "]);
+    // 仅空白文本视作无文本，不接管（避免发出一条只含空白的多余文本块）。
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:1 pendingText:@"   \n\t "]);
 }
 
 - (void)testAlbumAggregate_containsNonImage_doesNotAggregate {
-    // 含视频/其它（allImages=NO）：即使有文本也不聚合，走原路径，零回归。
-    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:NO imageCount:2 pendingText:@"看这个"]);
+    // 含视频/其它（allImages=NO）：即使有文本也不接管，走原路径，零回归。
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:NO assetCount:2 pendingText:@"看这个"]);
 }
 
-- (void)testAlbumAggregate_noImage_doesNotAggregate {
-    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:0 pendingText:@"看这个"]);
+- (void)testAlbumAggregate_noAsset_doesNotAggregate {
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES assetCount:0 pendingText:@"看这个"]);
 }
 
 @end

--- a/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
+++ b/Modules/WuKongBase/Example/Tests/WKRichTextSendTests.m
@@ -14,6 +14,7 @@
 
 @import XCTest;
 #import "WKRichTextContent.h"
+#import "WKApp.h"
 
 @interface WKRichTextSendTests : XCTestCase
 @end
@@ -121,6 +122,39 @@
     XCTAssertEqual(i.height, 20);
     XCTAssertEqual(i.size, 81920);
     XCTAssertEqualObjects(i.name, @"a.png");
+}
+
+#pragma mark - 相册选图 footgun 守卫（输入框有文本时不丢字）
+// octo-ios#21：相册选图发图前若输入框有待发文本，须把图+文本聚合成单条 RichText(=14)，
+// 不能只发图把文字静默丢掉。下面覆盖聚合决策的全部分支（含「选图时输入框有文本」回归）。
+
+- (void)testAlbumAggregate_imagesWithText_aggregates {
+    // 回归核心：选图时输入框有文本 → 走图文聚合（修复前是只发图丢文字）。
+    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:2 pendingText:@"看这个"]);
+}
+
+- (void)testAlbumAggregate_singleImageWithText_aggregates {
+    XCTAssertTrue([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:1 pendingText:@"hi"]);
+}
+
+- (void)testAlbumAggregate_imagesWithoutText_doesNotAggregate {
+    // 纯图无文本：原逐条发送路径不动，零回归。
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:3 pendingText:nil]);
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:3 pendingText:@""]);
+}
+
+- (void)testAlbumAggregate_whitespaceOnlyText_doesNotAggregate {
+    // 仅空白文本视作无文本，不聚合（避免发出一条只含空白的多余文本块）。
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:1 pendingText:@"   \n\t "]);
+}
+
+- (void)testAlbumAggregate_containsNonImage_doesNotAggregate {
+    // 含视频/其它（allImages=NO）：即使有文本也不聚合，走原路径，零回归。
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:NO imageCount:2 pendingText:@"看这个"]);
+}
+
+- (void)testAlbumAggregate_noImage_doesNotAggregate {
+    XCTAssertFalse([WKApp shouldAggregateAlbumImagesWithText:YES imageCount:0 pendingText:@"看这个"]);
 }
 
 @end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Panel/MoreItem/WKMoreItemClickEvent.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Panel/MoreItem/WKMoreItemClickEvent.m
@@ -112,21 +112,28 @@ static WKMoreItemClickEvent *_instance;
     __block NSInteger handleCount = 0;
     [[WKPhotoBrowser shared] showPreviewWithSender:[context targetVC] selectCompressImageBlock:^(NSArray<NSData *> * _Nonnull images, NSArray<PHAsset *> * _Nonnull assets, BOOL isOriginal) {
         // footgun 修复：相册选图时主聊天输入框已有待发文本 → 不能只发图把文字静默丢掉。
-        // 选中全为图片（无视频/其它）且输入框有非空白文本时，把「图 + 文本」聚合成单条
-        // RichText(=14)（复用 #19 落地的发送能力），图发出后清空输入框；任一条件不满足
-        // （有视频、纯图无文本）走原逐条发送路径，纯图零回归。
+        // 选中全为图片（无视频/其它）且输入框有非空白文本时，由图文聚合路径接管：把「图 +
+        // 文本」聚合成单条 RichText(=14)（复用 #19 落地的发送能力，最终走 [context sendMessage:]
+        // 保留全部会话语义），图发出后清空输入框。任一条件不满足（有视频、纯图无文本）走原
+        // 逐条发送路径，纯图零回归。
+        // 决策基于 assets.count（用户实际选中数），不看压缩结果 images.count——压缩可能丢图
+        // 甚至全丢，但只要选了图且有文本就必须接管（否则文本被原路径丢掉 + 原 loop 按
+        // assets 下标索引 images 越界崩溃）。压缩丢图的原子性由发送方法校验：丢图时整条
+        // 失败并恢复草稿。
         BOOL allImages = assets.count > 0;
         for (PHAsset *a in assets) {
             if (a.mediaType != PHAssetMediaTypeImage) { allImages = NO; break; }
         }
         NSString *pendingText = [weakContext inputText];
-        if ([WKApp shouldAggregateAlbumImagesWithText:allImages imageCount:images.count pendingText:pendingText]) {
+        if ([WKApp shouldAggregateAlbumImagesWithText:allImages assetCount:assets.count pendingText:pendingText]) {
             [weakContext inputSetText:@""]; // 文本随聚合消息发出，先清空输入框避免重复。
             // 发送失败则把草稿恢复回输入框——文字绝不被静默丢弃（footgun 修复核心保证）。
-            [[WKApp shared] sendRichTextMixedImageDatas:images extraText:pendingText toChannel:[weakContext channel] onFailure:^{
-                if ([weakContext inputText].length == 0) {
-                    [weakContext inputSetText:pendingText];
-                }
+            // 边界：上传在途时用户又输入了新内容 → 不能直接覆盖（会丢新内容），把原草稿
+            // 前置拼到当前输入前，两段文字都不丢。
+            [[WKApp shared] sendRichTextMixedImageDatas:images assetCount:assets.count extraText:pendingText inContext:weakContext onFailure:^{
+                NSString *current = [weakContext inputText] ?: @"";
+                NSString *restored = current.length == 0 ? pendingText : [NSString stringWithFormat:@"%@%@", pendingText, current];
+                [weakContext inputSetText:restored];
             }];
             return;
         }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Panel/MoreItem/WKMoreItemClickEvent.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Panel/MoreItem/WKMoreItemClickEvent.m
@@ -106,11 +106,31 @@ static WKMoreItemClickEvent *_instance;
    
     
     [context endEditing];
-    
+
     UIView *topView = [WKNavigationManager shared].topViewController.view;
-   
+
     __block NSInteger handleCount = 0;
     [[WKPhotoBrowser shared] showPreviewWithSender:[context targetVC] selectCompressImageBlock:^(NSArray<NSData *> * _Nonnull images, NSArray<PHAsset *> * _Nonnull assets, BOOL isOriginal) {
+        // footgun 修复：相册选图时主聊天输入框已有待发文本 → 不能只发图把文字静默丢掉。
+        // 选中全为图片（无视频/其它）且输入框有非空白文本时，把「图 + 文本」聚合成单条
+        // RichText(=14)（复用 #19 落地的发送能力），图发出后清空输入框；任一条件不满足
+        // （有视频、纯图无文本）走原逐条发送路径，纯图零回归。
+        BOOL allImages = assets.count > 0;
+        for (PHAsset *a in assets) {
+            if (a.mediaType != PHAssetMediaTypeImage) { allImages = NO; break; }
+        }
+        NSString *pendingText = [weakContext inputText];
+        if ([WKApp shouldAggregateAlbumImagesWithText:allImages imageCount:images.count pendingText:pendingText]) {
+            [weakContext inputSetText:@""]; // 文本随聚合消息发出，先清空输入框避免重复。
+            // 发送失败则把草稿恢复回输入框——文字绝不被静默丢弃（footgun 修复核心保证）。
+            [[WKApp shared] sendRichTextMixedImageDatas:images extraText:pendingText toChannel:[weakContext channel] onFailure:^{
+                if ([weakContext inputText].length == 0) {
+                    [weakContext inputSetText:pendingText];
+                }
+            }];
+            return;
+        }
+
         [topView showHUD:LLang(@"压缩中")];
         if(assets && assets.count>0) {
             handleCount = assets.count;

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.h
@@ -140,34 +140,52 @@ NS_ASSUME_NONNULL_BEGIN
  图文混排发送（RichText=14）：把多张已压缩的图片 + 附带文本聚合成单条消息。
 
  用于主聊天「相册选图时输入框已有文本」场景——避免图发出而文字被静默丢弃。每张图先
- 写入临时文件再走与分享入口一致的上传/构造链路（图 block 在前 + text block 在后），
- 任一图片失败则整条中止（原子性），成功/失败都会清理临时文件。
+ 写入临时文件再走与分享入口一致的上传/构造链路（图 block 在前 + text block 在后）。
 
- 调用方应在调用前清空输入框（避免重复发送）；若上传/构造在任一环节失败，`onFailure`
- 会在主线程回调，调用方据此把文本恢复到输入框，保证文字绝不被静默丢弃。
+ 与分享入口的根本区别：本方法在**活跃会话上下文**内发送，最终落地走 `context` 的
+ `sendMessage:`——与原相册单图发送（`[context sendMessage:WKImageContent]`）完全同一
+ 路径，从而保留回执设置 / 阅后即焚 expiry / spaceId / 父子频道 topic 路由 / reply
+ 元数据 / 本地 tracing + 列表插入等全部会话语义；绝不退化为 `forwardMessage:`（裸
+ save+send）那样绕过这些装饰。
+
+ 原子性（全发或全不发）：进入聚合发送前先校验 `imageDatas.count == assetCount`
+ （压缩阶段未丢图），再要求**每一张**图都成功落盘；任一条件不满足 → 整条中止、弹
+ 「发送失败」HUD、回调 `onFailure` 恢复草稿。绝不静默只发其中几张（违反原子性声明）。
+
+ 调用方应在调用前清空输入框（避免重复发送）；若任一环节失败，`onFailure` 会在主线程
+ 回调，调用方据此把文本恢复到输入框，保证文字绝不被静默丢弃。
 
  @param imageDatas 已压缩的图片二进制（与相册回调一致，顺序即展示顺序）
+ @param assetCount 用户实际选中的图片资产数量（用于原子性校验：压缩阶段是否丢图）
  @param extraText  输入框待发文本（调用方保证非空白）
- @param channel    目标会话
+ @param context    当前会话上下文（最终消息走 `context.sendMessage:`，channel 取自其中）
  @param onFailure  发送失败时主线程回调（用于恢复输入框草稿），可为 nil
  */
 -(void) sendRichTextMixedImageDatas:(NSArray<NSData*>*)imageDatas
+                         assetCount:(NSUInteger)assetCount
                           extraText:(NSString*)extraText
-                          toChannel:(WKChannel*)channel
+                          inContext:(id<WKConversationContext>)context
                           onFailure:(void(^_Nullable)(void))onFailure;
 
 /**
- 相册选图发送决策（footgun 守卫，纯函数，便于单测）：仅当选中全为图片、至少一张、
- 且输入框存在非空白待发文本时，才把「图 + 文本」聚合成单条 RichText(=14)；否则走原
- 逐条发送路径（纯图 / 含视频 / 无文本零回归）。
+ 相册选图「是否由图文聚合路径接管」决策（footgun 守卫，纯函数，便于单测）：仅当选中
+ 全为图片、至少选了一张（assetCount>0）、且输入框存在非空白待发文本时，才由聚合路径
+ 接管（把图 + 文本聚合成单条 RichText(=14)）；否则走原逐条发送路径（纯图 / 含视频 /
+ 无文本零回归）。
+
+ 关键：决策基于**用户实际选中的图片资产数**（assetCount），不依赖压缩结果数——只要
+ 选了图且有文本就必须接管。绝不能因「压缩丢图」（压缩后图变少甚至为 0）退回原逐条
+ 路径，否则 (a) 文本被原路径丢掉（即 #21 footgun），(b) 原逐条 loop 会按 assets 下标
+ 索引 images 数组越界崩溃。压缩丢图的原子性在接管后的发送方法内校验
+ （`imageDatas.count == assetCount` 不满足 → 整条失败并恢复草稿）。
 
  @param allImages   选中项是否全部为图片（含「至少选了一项」的语义由调用方保证传入）
- @param imageCount  选中的图片数量
+ @param assetCount  用户实际选中的图片资产数量
  @param pendingText 输入框当前文本（未 trim，内部做空白裁剪判定）
- @return YES 表示应走图文聚合路径
+ @return YES 表示应由图文聚合路径接管
  */
 + (BOOL)shouldAggregateAlbumImagesWithText:(BOOL)allImages
-                                imageCount:(NSUInteger)imageCount
+                                assetCount:(NSUInteger)assetCount
                                pendingText:(nullable NSString *)pendingText;
 
 /**

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.h
@@ -137,6 +137,40 @@ NS_ASSUME_NONNULL_BEGIN
 -(NSArray*) invokes:(NSString*)category param:(__nullable id)param;
 
 /**
+ 图文混排发送（RichText=14）：把多张已压缩的图片 + 附带文本聚合成单条消息。
+
+ 用于主聊天「相册选图时输入框已有文本」场景——避免图发出而文字被静默丢弃。每张图先
+ 写入临时文件再走与分享入口一致的上传/构造链路（图 block 在前 + text block 在后），
+ 任一图片失败则整条中止（原子性），成功/失败都会清理临时文件。
+
+ 调用方应在调用前清空输入框（避免重复发送）；若上传/构造在任一环节失败，`onFailure`
+ 会在主线程回调，调用方据此把文本恢复到输入框，保证文字绝不被静默丢弃。
+
+ @param imageDatas 已压缩的图片二进制（与相册回调一致，顺序即展示顺序）
+ @param extraText  输入框待发文本（调用方保证非空白）
+ @param channel    目标会话
+ @param onFailure  发送失败时主线程回调（用于恢复输入框草稿），可为 nil
+ */
+-(void) sendRichTextMixedImageDatas:(NSArray<NSData*>*)imageDatas
+                          extraText:(NSString*)extraText
+                          toChannel:(WKChannel*)channel
+                          onFailure:(void(^_Nullable)(void))onFailure;
+
+/**
+ 相册选图发送决策（footgun 守卫，纯函数，便于单测）：仅当选中全为图片、至少一张、
+ 且输入框存在非空白待发文本时，才把「图 + 文本」聚合成单条 RichText(=14)；否则走原
+ 逐条发送路径（纯图 / 含视频 / 无文本零回归）。
+
+ @param allImages   选中项是否全部为图片（含「至少选了一项」的语义由调用方保证传入）
+ @param imageCount  选中的图片数量
+ @param pendingText 输入框当前文本（未 trim，内部做空白裁剪判定）
+ @return YES 表示应走图文聚合路径
+ */
++ (BOOL)shouldAggregateAlbumImagesWithText:(BOOL)allImages
+                                imageCount:(NSUInteger)imageCount
+                               pendingText:(nullable NSString *)pendingText;
+
+/**
  设置方法
 
  @param sid poit唯一id

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -120,6 +120,9 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 
 // 图文混排（RichText=14）发送私有方法（在 sendShareFiles: 之后定义，此处前置声明）。
 -(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel;
+// 上传核心：cleanup 在成功/失败终态都会执行，由调用方决定清理对象（分享目录 / 临时文件）；
+// onFailure 仅在失败终态主线程回调（用于恢复输入框草稿等）。
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^_Nullable)(void))cleanup onFailure:(void(^_Nullable)(void))onFailure;
 - (NSString *)richTextMimeForExtension:(NSString *)ext;
 
 /**
@@ -2221,6 +2224,18 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
  * - 上传/网络在后台线程链式串行，全部就绪后回主线程构造并发送一条消息。
  */
 -(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel {
+    // 分享入口：终态清理拷进 App Group 的分享目录（成功/失败都清，与原逐条路径对称）。
+    // 分享入口无输入框草稿，onFailure 传 nil（失败已由 HUD 提示）。
+    [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:channel cleanup:^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
+            NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:_OctoShareAppGroupId()];
+            NSURL *dir = [container URLByAppendingPathComponent:kShareDirName];
+            [[NSFileManager defaultManager] removeItemAtURL:dir error:nil];
+        });
+    } onFailure:nil];
+}
+
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^)(void))cleanup onFailure:(void(^)(void))onFailure {
     UIView *topView = [WKNavigationManager shared].topViewController.view;
     [topView showHUD:LLang(@"发送中")];
 
@@ -2243,13 +2258,9 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
     // 终态显式置 nil 打破 retain cycle，避免泄漏。
     __block void (^uploadNext)(NSUInteger) = nil;
 
-    // 分享目录清理：成功/失败都要清，避免失败时把拷进来的分享文件残留（与原路径对称）。
+    // 终态清理：成功/失败都执行调用方注入的 cleanup（分享目录 / 临时文件），避免残留。
     void (^cleanupShareDir)(void) = ^{
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
-            NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:_OctoShareAppGroupId()];
-            NSURL *dir = [container URLByAppendingPathComponent:kShareDirName];
-            [[NSFileManager defaultManager] removeItemAtURL:dir error:nil];
-        });
+        if (cleanup) cleanup();
     };
 
     void (^fail)(void) = ^{
@@ -2259,6 +2270,8 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [topView hideHud];
             [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送失败")];
+            // 失败先恢复草稿（图文聚合发送整条中止 → 文字不能丢），再清理临时资源。
+            if (onFailure) onFailure();
             cleanupShareDir();
         });
     };
@@ -2375,6 +2388,73 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
     if ([ext isEqualToString:@"webp"]) return @"image/webp";
     if ([ext isEqualToString:@"heic"]) return @"image/heic";
     return @"image/jpeg";
+}
+
+// 由图片二进制内容嗅探扩展名（相册回调给的是已压缩 NSData，没有文件名/路径）。
+// 用于构造临时文件名与上传 MIME，未知格式回退 jpg（与上传 MIME 默认一致）。
+static NSString *_WKRichTextExtForImageData(NSData *data) {
+    SDImageFormat fmt = [NSData sd_imageFormatForImageData:data];
+    switch (fmt) {
+        case SDImageFormatPNG:  return @"png";
+        case SDImageFormatGIF:  return @"gif";
+        case SDImageFormatWebP: return @"webp";
+        case SDImageFormatHEIC:
+        case SDImageFormatHEIF: return @"heic";
+        case SDImageFormatJPEG:
+        default:                return @"jpg";
+    }
+}
+
++ (BOOL)shouldAggregateAlbumImagesWithText:(BOOL)allImages
+                                imageCount:(NSUInteger)imageCount
+                               pendingText:(NSString *)pendingText {
+    if (!allImages || imageCount == 0) return NO;
+    NSString *trimmed = [pendingText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return trimmed.length > 0;
+}
+
+-(void) sendRichTextMixedImageDatas:(NSArray<NSData*>*)imageDatas
+                          extraText:(NSString*)extraText
+                          toChannel:(WKChannel*)channel
+                          onFailure:(void(^)(void))onFailure {
+    // 主聊天「相册选图 + 输入框有文本」：先把每张已压缩图片落临时文件（上传链路与分享
+    // 入口共用，按文件路径走，不依赖内存里的 NSData），再聚合成单条 RichText(=14)。
+    NSString *trimmed = [extraText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0 || imageDatas.count == 0) {
+        if (onFailure) onFailure(); // 防御：无文本或无图不应进此路径（调用方已判定）；仍恢复草稿。
+        return;
+    }
+
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                        [NSString stringWithFormat:@"richtext-album-%@", [[NSUUID UUID] UUIDString]]];
+    [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir withIntermediateDirectories:YES attributes:nil error:nil];
+
+    NSMutableArray<NSDictionary *> *fileInfos = [NSMutableArray array];
+    for (NSUInteger i = 0; i < imageDatas.count; i++) {
+        NSData *data = imageDatas[i];
+        if (data.length == 0) continue;
+        NSString *ext = _WKRichTextExtForImageData(data);
+        NSString *fileName = [NSString stringWithFormat:@"image_%lu.%@", (unsigned long)i, ext];
+        NSString *path = [tmpDir stringByAppendingPathComponent:fileName];
+        if ([data writeToFile:path atomically:YES]) {
+            [fileInfos addObject:@{@"type": @"image", @"path": path}];
+        }
+    }
+
+    // 落盘全失败（极端磁盘异常）：恢复草稿（文字绝不丢），清理空临时目录后返回。
+    if (fileInfos.count == 0) {
+        [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
+        if (onFailure) onFailure();
+        return;
+    }
+
+    // 终态清理：删整个临时目录（成功/失败都执行），与分享入口清理对称；失败时回调
+    // onFailure 让调用方恢复输入框草稿。
+    [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:channel cleanup:^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
+            [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
+        });
+    } onFailure:onFailure];
 }
 
 

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -121,8 +121,10 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 // 图文混排（RichText=14）发送私有方法（在 sendShareFiles: 之后定义，此处前置声明）。
 -(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel;
 // 上传核心：cleanup 在成功/失败终态都会执行，由调用方决定清理对象（分享目录 / 临时文件）；
-// onFailure 仅在失败终态主线程回调（用于恢复输入框草稿等）。
--(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^_Nullable)(void))cleanup onFailure:(void(^_Nullable)(void))onFailure;
+// onFailure 仅在失败终态主线程回调（用于恢复输入框草稿等）；send 由调用方注入「内容就绪后
+// 如何发送 + 插入列表」——分享入口走 forwardMessage:（无会话上下文），主聊天相册入口走
+// [context sendMessage:]（保留回执/阅后即焚/spaceId/topic/reply/tracing/列表插入等全部会话语义）。
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^_Nullable)(void))cleanup onFailure:(void(^_Nullable)(void))onFailure send:(void(^)(WKRichTextContent *content))send;
 - (NSString *)richTextMimeForExtension:(NSString *)ext;
 
 /**
@@ -2226,16 +2228,26 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
 -(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel {
     // 分享入口：终态清理拷进 App Group 的分享目录（成功/失败都清，与原逐条路径对称）。
     // 分享入口无输入框草稿，onFailure 传 nil（失败已由 HUD 提示）。
+    // 分享入口没有活跃会话上下文（从系统分享面板拉起），无法走 context.sendMessage:，
+    // 故 send 用 forwardMessage:（裸 save+send）+ 通知驱动列表插入——这是分享场景的既有
+    // 行为，会话语义（回执/阅后即焚/topic 等）在分享入口本就不适用。
     [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:channel cleanup:^{
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
             NSURL *container = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:_OctoShareAppGroupId()];
             NSURL *dir = [container URLByAppendingPathComponent:kShareDirName];
             [[NSFileManager defaultManager] removeItemAtURL:dir error:nil];
         });
-    } onFailure:nil];
+    } onFailure:nil send:^(WKRichTextContent *content) {
+        WKMessage *msg = [[WKSDK shared].chatManager forwardMessage:content channel:channel];
+        if (msg) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"WKShareExtensionMessageSent" object:channel userInfo:@{@"messages": @[msg]}];
+            });
+        }
+    }];
 }
 
--(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^)(void))cleanup onFailure:(void(^)(void))onFailure {
+-(void) sendRichTextMixedImages:(NSArray *)fileInfos extraText:(NSString *)extraText toChannel:(WKChannel *)channel cleanup:(void(^)(void))cleanup onFailure:(void(^)(void))onFailure send:(void(^)(WKRichTextContent *content))send {
     UIView *topView = [WKNavigationManager shared].topViewController.view;
     [topView showHUD:LLang(@"发送中")];
 
@@ -2276,7 +2288,10 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
         });
     };
 
-    // 全部图片就绪后：主线程构造单条 RichText 并发送（image blocks 在前 + text block 在后）。
+    // 全部图片就绪后：主线程构造单条 RichText 并通过调用方注入的 send 发送。
+    // send 决定走哪条发送路径：分享入口 forwardMessage:（无会话上下文）；主聊天相册入口
+    // [context sendMessage:]（保留全部会话语义）。本核心方法只负责「装配内容 + 终态收口」，
+    // 不再硬编码 forwardMessage:，避免相册聚合路径绕过会话发送装饰（footgun 修复核心）。
     void (^finish)(void) = ^{
         if (settled) return;
         settled = YES;
@@ -2285,14 +2300,9 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
             NSMutableArray<WKRichTextBlock *> *blocks = [imageBlocks mutableCopy];
             [blocks addObject:[WKRichTextContent textBlock:extraText]];
             WKRichTextContent *content = [WKRichTextContent contentWithBlocks:blocks];
-            WKMessage *msg = [[WKSDK shared].chatManager forwardMessage:content channel:channel];
             [topView hideHud];
             [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送成功")];
-            if (msg) {
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    [[NSNotificationCenter defaultCenter] postNotificationName:@"WKShareExtensionMessageSent" object:channel userInfo:@{@"messages": @[msg]}];
-                });
-            }
+            if (send) send(content);
             cleanupShareDir();
         });
     };
@@ -2406,22 +2416,39 @@ static NSString *_WKRichTextExtForImageData(NSData *data) {
 }
 
 + (BOOL)shouldAggregateAlbumImagesWithText:(BOOL)allImages
-                                imageCount:(NSUInteger)imageCount
+                                assetCount:(NSUInteger)assetCount
                                pendingText:(NSString *)pendingText {
-    if (!allImages || imageCount == 0) return NO;
+    if (!allImages || assetCount == 0) return NO;
+    // 决策基于用户实际选中的图片资产数（assetCount），不看压缩结果数：只要选了图且输入框
+    // 有非空白文本就接管。绝不能因压缩丢图退回原逐条路径——否则文本被原路径丢掉（#21
+    // footgun），且原 loop 会按 assets 下标索引压缩后的 images 数组越界崩溃。压缩丢图的
+    // 原子性校验在 sendRichTextMixedImageDatas: 内做（imageDatas.count != assetCount →
+    // 整条失败 + 恢复草稿）。
     NSString *trimmed = [pendingText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     return trimmed.length > 0;
 }
 
 -(void) sendRichTextMixedImageDatas:(NSArray<NSData*>*)imageDatas
+                         assetCount:(NSUInteger)assetCount
                           extraText:(NSString*)extraText
-                          toChannel:(WKChannel*)channel
+                          inContext:(id<WKConversationContext>)context
                           onFailure:(void(^)(void))onFailure {
     // 主聊天「相册选图 + 输入框有文本」：先把每张已压缩图片落临时文件（上传链路与分享
     // 入口共用，按文件路径走，不依赖内存里的 NSData），再聚合成单条 RichText(=14)。
+    // 失败统一收口：弹「发送失败」HUD + 回调 onFailure 恢复草稿（文字绝不静默丢）。
+    // selectCompressImageBlock 可能在后台压缩回调线程触发本方法，UI/草稿恢复一律切主线程。
+    void (^failEarly)(void) = ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送失败")];
+            if (onFailure) onFailure();
+        });
+    };
+
     NSString *trimmed = [extraText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if (trimmed.length == 0 || imageDatas.count == 0) {
-        if (onFailure) onFailure(); // 防御：无文本或无图不应进此路径（调用方已判定）；仍恢复草稿。
+    // 原子性闸门（Critical 2）：无文本/无图/无上下文，或压缩阶段丢了图
+    // （imageDatas.count != assetCount）→ 整条失败，绝不只发部分图。
+    if (trimmed.length == 0 || imageDatas.count == 0 || context == nil || imageDatas.count != assetCount) {
+        failEarly();
         return;
     }
 
@@ -2429,32 +2456,43 @@ static NSString *_WKRichTextExtForImageData(NSData *data) {
                         [NSString stringWithFormat:@"richtext-album-%@", [[NSUUID UUID] UUIDString]]];
     [[NSFileManager defaultManager] createDirectoryAtPath:tmpDir withIntermediateDirectories:YES attributes:nil error:nil];
 
+    // 原子性（Critical 2）：每一张选中图都必须有非空数据且成功落盘，任一张失败 → 整条
+    // 中止、清理临时目录、恢复草稿。绝不静默丢掉失败那张只发其余（违反原子性声明）。
     NSMutableArray<NSDictionary *> *fileInfos = [NSMutableArray array];
+    BOOL allWritten = YES;
     for (NSUInteger i = 0; i < imageDatas.count; i++) {
         NSData *data = imageDatas[i];
-        if (data.length == 0) continue;
+        if (data.length == 0) { allWritten = NO; break; }
         NSString *ext = _WKRichTextExtForImageData(data);
         NSString *fileName = [NSString stringWithFormat:@"image_%lu.%@", (unsigned long)i, ext];
         NSString *path = [tmpDir stringByAppendingPathComponent:fileName];
         if ([data writeToFile:path atomically:YES]) {
             [fileInfos addObject:@{@"type": @"image", @"path": path}];
+        } else {
+            allWritten = NO;
+            break;
         }
     }
 
-    // 落盘全失败（极端磁盘异常）：恢复草稿（文字绝不丢），清理空临时目录后返回。
-    if (fileInfos.count == 0) {
+    // 任一图片数据为空或落盘失败：整条中止，恢复草稿（文字绝不丢），清理临时目录后返回。
+    if (!allWritten || fileInfos.count != imageDatas.count) {
         [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
-        if (onFailure) onFailure();
+        failEarly();
         return;
     }
 
     // 终态清理：删整个临时目录（成功/失败都执行），与分享入口清理对称；失败时回调
     // onFailure 让调用方恢复输入框草稿。
-    [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:channel cleanup:^{
+    // send：相册入口在活跃会话上下文内发送，走 [context sendMessage:]——与原相册单图发送
+    // 同一路径，保留回执/阅后即焚 expiry/spaceId/父子频道 topic/reply 元数据/本地
+    // tracing + 列表插入等全部会话语义（Critical 1 修复核心：不走 forwardMessage: 绕过）。
+    [self sendRichTextMixedImages:fileInfos extraText:extraText toChannel:context.channel cleanup:^{
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(0, 0), ^{
             [[NSFileManager defaultManager] removeItemAtPath:tmpDir error:nil];
         });
-    } onFailure:onFailure];
+    } onFailure:onFailure send:^(WKRichTextContent *content) {
+        [context sendMessage:content];
+    }];
 }
 
 


### PR DESCRIPTION
## Problem

PR #19 documented the footgun: the main chat album picker (`onPhotoItemPressed`) sends selected images immediately and **ignores text already typed in the input box**. A user who types a sentence and then picks a photo sees the image go out while the sentence is **silently discarded** (#21).

## Fix (minimal, independent of Phase 2)

- In the album callback, when the selection is **all images** and the input box holds **non-blank text**, aggregate image(s) + text into a single `RichText(=14)` message, reusing the send-side capability landed in #19 (`sendRichTextMixedImages:extraText:`). Image blocks first + text block last, matching #19's reading order.
- **Pure-image, with-video, and no-text paths are untouched** — they keep the existing per-item send. Zero regression.
- The typed text is **never silently lost**:
  - Input box is cleared before the async send (avoids duplicate sends), and
  - a new `onFailure` hook restores the draft back into the input box if the aggregate upload/build fails at any step (atomic — never sends half).

## Implementation

- Refactored #19's uploader core to take an injected `cleanup` block, so both the Share Extension (App Group share dir) and the new album path (temp dir) reuse the same atomic upload+build chain. Added an `onFailure` terminal hook.
- New `sendRichTextMixedImageDatas:extraText:toChannel:onFailure:` for the album path, which receives already-compressed `NSData` (not file paths): each image is written to a temp file, sniffed for format via SDWebImage, then run through the shared chain; temp dir is cleaned up on both success and failure.
- Extracted the branch decision into a pure function `+shouldAggregateAlbumImagesWithText:imageCount:pendingText:` for unit testing.

## Tests

Added regression coverage in `WKRichTextSendTests` for the decision helper, including the **"album select while input has text"** case plus the no-text / whitespace-only / contains-non-image / no-image branches.

> Build/test runs on macOS CI (`xcodebuild`); could not compile locally on Linux.

Fixes #21