### PR TITLE
fix(richtext): caption 发送崩溃 — defer uploadNext 退链至 async 块 (Fixes #25)

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -2278,10 +2278,17 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
     void (^fail)(void) = ^{
         if (settled) return;
         settled = YES;
-        uploadNext = nil;
+        // 退链（打破 uploadNext↔completion 的 retain cycle）必须推迟到主线程 async block 内：
+        // fail/finish 经由 uploadNext 调到，此刻 uploadNext 往往是 fail/finish 自身唯一的强持有
+        // 者；若在此处同步 `uploadNext = nil`，会把正在执行的 fail/finish 块（及其捕获的
+        // cleanupShareDir/topView 等）当场释放，随后构造的 async block 捕获到的就是悬垂指针，
+        // 异步执行到 cleanupShareDir() 时 call 野 block → EXC_BAD_ACCESS（崩在 block_invoke_2）。
+        // 放进 async block：① 内层 block 独立 retain 住 cleanupShareDir/topView 等捕获，与
+        // uploadNext 生命周期解耦；② 退链发生在 fail/finish 早已返回之后，绝不自释放执行中的块。
         dispatch_async(dispatch_get_main_queue(), ^{
+            uploadNext = nil;
             [topView hideHud];
-            [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送失败")];
+            [topView showHUDWithHide:LLang(@"发送失败")];
             // 失败先恢复草稿（图文聚合发送整条中止 → 文字不能丢），再清理临时资源。
             if (onFailure) onFailure();
             cleanupShareDir();
@@ -2295,13 +2302,20 @@ static CGSize _WKRichTextImagePixelSize(NSString *path) {
     void (^finish)(void) = ^{
         if (settled) return;
         settled = YES;
-        uploadNext = nil;
+        // 退链推迟到主线程 async block 内（同 fail 注释的根因）：在此处同步 `uploadNext = nil`
+        // 会释放正在执行的 finish 块本体，其捕获的 cleanupShareDir/topView 等随之悬垂，async
+        // block 异步执行到 2306 `cleanupShareDir()` 时 call 野 block → EXC_BAD_ACCESS。
         dispatch_async(dispatch_get_main_queue(), ^{
+            uploadNext = nil;
             NSMutableArray<WKRichTextBlock *> *blocks = [imageBlocks mutableCopy];
             [blocks addObject:[WKRichTextContent textBlock:extraText]];
             WKRichTextContent *content = [WKRichTextContent contentWithBlocks:blocks];
+            // 异步收尾时 topViewController 可能已切换（用户发完立即退会话/切频道），topView 与
+            // 当前 topViewController.view 已不是同一个；hideHud/showHUD 都用捕获的 topView 快照，
+            // 不再二次取 [WKNavigationManager shared].topViewController.view，避免对已易主的 UI
+            // 误操作。topView 为 strong 捕获，async 执行期间稳定存活，nil 时消息无副作用。
             [topView hideHud];
-            [[WKNavigationManager shared].topViewController.view showHUDWithHide:LLang(@"发送成功")];
+            [topView showHUDWithHide:LLang(@"发送成功")];
             if (send) send(content);
             cleanupShareDir();
         });


### PR DESCRIPTION
## 问题
P0，崩在已上线功能。主聊天图文混排：相册选图 + caption 确认页 → 点发送，崩溃。栈顶：

```
#0 __76-[WKApp sendRichTextMixedImages:extraText:toChannel:cleanup:onFailure:send:]_block_invoke_2.783
   at WKApp.m:2306   // cleanupShareDir();
```

## 根因 — EXC_BAD_ACCESS，执行中的 block 被自释放
6-arg `sendRichTextMixedImages:...cleanup:onFailure:send:` 的 `finish`/`fail` 块里，
`uploadNext = nil` 在构造主线程 `dispatch_async` 闭包**之前**同步执行。

`finish`/`fail` 是经由 `uploadNext` 的 completion 链调进来的，此刻 `uploadNext` 往往是
`finish`/`fail` 自身唯一的强持有者（ARC）。在那一行 nil 掉 `uploadNext`，等于在块还在栈上
执行时就把它本体（连同它捕获的 `cleanupShareDir` 堆 block、`topView` 等）释放掉。随后
new 出来的 async 闭包捕获到的就是悬垂指针；异步回到主线程跑到 `cleanupShareDir()`
（2306）时 call 一个已释放的 block → EXC_BAD_ACCESS，崩在 `block_invoke_2`。

这是 PR #24（caption 确认页）新引入路径独有的暴露面；分享入口 `forwardMessage:` 此前未报。

## 修复
- 把退链 `uploadNext = nil` 从 `finish`/`fail` 同步段**推迟进各自的 async 块内**：
  - async 块独立 retain 住 `cleanupShareDir`/`topView`/`imageBlocks` 等捕获，与
    `uploadNext` 生命周期解耦；
  - 退链发生在 `finish`/`fail` 早已返回之后，绝不再自释放执行中的块。
- `settled = YES` 仍同步执行，重入守卫不变；上传串行，无 in-flight 回调竞态；async 块
  必然执行 → retain cycle 仍始终被打破，不泄漏。
- 成功/失败 HUD 改用捕获的 `topView` 快照，不再异步时二次取
  `[WKNavigationManager shared].topViewController.view`——用户发完立即退会话/切频道时
  topVC 已易主，避免对错误 VC 误操作。

## 硬约束确认
- ✅ 文字不静默丢：`onFailure` 恢复草稿语义不变（仅移动 nil 退链时机）。
- ✅ type=14 wire schema 不动；发送路径（`context.sendMessage:` / `forwardMessage:`）不动。

## 复现步骤（修复前后对比）
1. 主聊天进会话，相册多选 N 张图；caption 页填字 → 发送。
2. 修复前：上传成功 `finish` 异步收尾 call 野 `cleanupShareDir` block → 崩 `WKApp.m:2306`。
   发完立即退会话/切频道放大 topView 时序。
3. 修复后：退链在 async 内、捕获存活，收尾正常发出 + 清理临时目录，无崩溃。

Fixes #25
