### PR TITLE
ci: pin all GitHub Actions to exact SHA digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('Podfile.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,10 +30,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3
         with:
           languages: swift
 
@@ -47,7 +47,7 @@ jobs:
         run: cp OctoConfig.xcconfig.template OctoConfig.xcconfig
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3


### PR DESCRIPTION
## What

Replace all tag-based action references (`@v3`/`@v4`) with SHA-pinned versions plus version comments across both CI and CodeQL workflow files.

## Why

Tag refs can be force-pushed, creating a supply chain attack vector. SHA pinning ensures the exact code version is used. This aligns with the org standard already followed by other Mininglamp-OSS repos.

## Changes

**ci.yml:**
- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `actions/cache@v4` → `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4`

**codeql.yml:**
- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `github/codeql-action/init@v3` → `github/codeql-action/init@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3`
- `github/codeql-action/autobuild@v3` → `github/codeql-action/autobuild@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3`
- `github/codeql-action/analyze@v3` → `github/codeql-action/analyze@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3`

## Verification

```
grep -r '@v[0-9]' .github/workflows/
```
Returns empty — all actions are now SHA-pinned.