### PR TITLE
fix(conversation): 打开会话定位"首条未读" (群/私聊/子区统一)

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
@@ -401,27 +401,45 @@
     if(newMsgCount > 0 && conversationLastMessage) {
         uint32_t lastReadSeq = [[WKUnreadStore shared] lastReadSeqForChannel:self.channel];
         uint32_t lastMsgSeq = [[WKSDK shared].chatManager getOrNearbyMessageSeq:conversationLastMessage.orderSeq];
-        // readBoundary = "最后一条已读" 的 seq:
-        //   - 首选 lastReadSeq (上次离开会话时精确写入, 不受撤回/删除/推送 race 影响)
-        //   - 兜底 lastMsgSeq - newMsgCount (与原算法语义完全对齐, lastReadSeq=0 时用)
-        uint32_t readBoundarySeq = 0;
-        if (lastReadSeq > 0 && lastMsgSeq > lastReadSeq) {
-            readBoundarySeq = lastReadSeq;
-        } else if (lastMsgSeq > newMsgCount) {
-            readBoundarySeq = (uint32_t)(lastMsgSeq - newMsgCount);
+        // 关键: count-axis 和 anchor-axis 必须解耦, 之前一版 (#33 R1) 把两者绑到
+        // 同一个变量 (browseToOrderSeq=keepOrderSeq=lastReadSeq) 引入了红点偏离
+        // bug (PR #33 R6 yujiawei P1-1):
+        //   refreshNewMsgCount 用 lastMsgSeq - browseToMessageSeq 算红点,
+        //   browseToOrderSeq = getOrderSeq(lastReadSeq) → 红点 = lastMsgSeq - lastReadSeq
+        //   而 server unreadCount 算的是真未读数, 任何 own message / 撤回 / 删除
+        //   落在 (lastReadSeq, lastMsgSeq] 都会让 seq gap > 真 unreadCount → 红点偏大
+        //   并写回会话列表 model.unreadCount 推错值。
+        // 修法:
+        //   - browseToOrderSeq 回归原算法 getOrderSeq(lastMsgSeq - newMsgCount)
+        //     count-axis 与 server unreadCount 自洽, refreshNewMsgCount 算出来的
+        //     红点 = lastMsgSeq - (lastMsgSeq - newMsgCount) = newMsgCount, 一致
+        //   - keepOrderSeq (滚动锚点) 用 lastReadSeq, anchor 鲁棒, 已读消息肯定
+        //     loaded, 即便首条未读 (lastReadSeq+1) 被撤回 indexPath 拿不到, 仍能
+        //     命中 lastReadSeq 完成定位, 不退化到 scrollToBottom (这是 #33 引入
+        //     lastReadSeq 的本意)
+        //   - 两个 axis 独立, fallback (lastReadSeq=0) 时 keepOrderSeq 退到 count
+        //     一致的 readBoundary, 行为不变。
+        if (lastMsgSeq > newMsgCount) {
+            // count-axis: refreshNewMsgCount 用 browseToOrderSeq 算红点
+            uint32_t countBoundarySeq = (uint32_t)(lastMsgSeq - newMsgCount);
+            uint32_t countBoundaryOrderSeq = [[WKSDK shared].chatManager getOrderSeq:countBoundarySeq];
+            if (countBoundaryOrderSeq > 0) {
+                self.messageListView.browseToOrderSeq = countBoundaryOrderSeq;
+            }
         }
-        if (readBoundarySeq > 0) {
-            uint32_t readBoundaryOrderSeq = [[WKSDK shared].chatManager getOrderSeq:readBoundarySeq];
-            if (readBoundaryOrderSeq > 0) {
-                // browseToOrderSeq 必须保持"已读边界"语义 (refreshNewMsgCount 用它算红点数,
-                // insertHistoryMsgSplitUI 在它之后插「以下是新消息」分割线), 不能换成
-                // 首条未读 seq, 否则红点偏小 1 + 首条未读被划成已读 (PR #33 R1 review)。
-                self.messageListView.browseToOrderSeq = readBoundaryOrderSeq;
-                // keepPosition 也锚定到 readBoundary (已读消息肯定 loaded, 不受撤回影响),
-                // 靠 offset = -120 把视口下推一行, 让首条未读 (readBoundary 下方) 自然
-                // 出现在视口顶部。即便首条未读 (lastReadSeq+1) 是撤回消息 indexPath 拿
-                // 不到, 也仍能命中 readBoundary 完成定位, 不退化到 scrollToBottom。
-                keepOrderSeq = readBoundaryOrderSeq;
+        // anchor-axis: keepPosition 锚到 lastReadSeq (已读消息必 loaded);
+        // 没 lastReadSeq 时 fallback 到 count-axis 的 readBoundary (与原行为一致)。
+        uint32_t anchorSeq = 0;
+        if (lastReadSeq > 0 && lastMsgSeq > lastReadSeq) {
+            anchorSeq = lastReadSeq;
+        } else if (lastMsgSeq > newMsgCount) {
+            anchorSeq = (uint32_t)(lastMsgSeq - newMsgCount);
+        }
+        if (anchorSeq > 0) {
+            uint32_t anchorOrderSeq = [[WKSDK shared].chatManager getOrderSeq:anchorSeq];
+            if (anchorOrderSeq > 0) {
+                // 视口下推一行让首条未读 (anchorSeq+1) 自然出现在视口顶部。
+                keepOrderSeq = anchorOrderSeq;
                 keepOffSetY = -120.0f;
             }
         }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
@@ -382,23 +382,41 @@
 }
 
 -(void) calcKeepPositionAndBrowseToOrderSeq {
-    
+
     if(!self.currentConversation) {
         return;
     }
-    
+
     NSInteger keepOffSetY = 0;
     uint32_t keepOrderSeq = 0;
     NSInteger newMsgCount = self.currentConversation.unreadCount;
     WKMessage *conversationLastMessage = self.currentConversation.lastMessage;
-    if(newMsgCount>0) { // 有新消息，则定位到新消息第一条
-        uint32_t lastMessageSeq = [[WKSDK shared].chatManager getOrNearbyMessageSeq:conversationLastMessage.orderSeq];
-        if(lastMessageSeq>newMsgCount) {
-            self.messageListView.browseToOrderSeq= [[WKSDK shared].chatManager getOrderSeq:lastMessageSeq - (uint32_t)newMsgCount];
-            keepOrderSeq = self.messageListView.browseToOrderSeq;
-            keepOffSetY = -120.0f;
+    // 微信式打开会话定位"首条未读"。优先用 WKUnreadStore.lastReadSeq + 1 作锚点
+    // (精确, 不受撤回/删除/推送 race 影响); 兜底 lastMessageSeq - unreadCount
+    // (新会话 lastReadSeq=0 或 lastReadSeq 异常时用)。
+    //
+    // 为何不再单纯依赖 unreadCount: 群里有撤回/删除时 seq 不连续, last - unread
+    // 可能落到已删除消息 seq → getOrderSeq 返 0 → keepPosition 失效退化到最底部;
+    // 子区/远端 reconcile race 也可能让 unreadCount 偏小, 同样退化。
+    if(newMsgCount > 0 && conversationLastMessage) {
+        uint32_t firstUnreadSeq = 0;
+        uint32_t lastReadSeq = [[WKUnreadStore shared] lastReadSeqForChannel:self.channel];
+        uint32_t lastMsgSeq = [[WKSDK shared].chatManager getOrNearbyMessageSeq:conversationLastMessage.orderSeq];
+        if (lastReadSeq > 0 && lastMsgSeq > lastReadSeq) {
+            // 首选: 上次离开会话时已确认读到 lastReadSeq, 下一条 (lastReadSeq+1) 就是首条未读
+            firstUnreadSeq = lastReadSeq + 1;
+        } else if (lastMsgSeq > newMsgCount) {
+            // 兜底: 没有 lastReadSeq 时 (首次进/旧版本数据), 用 last - unread 近似
+            firstUnreadSeq = (uint32_t)(lastMsgSeq - newMsgCount + 1);
         }
-        
+        if (firstUnreadSeq > 0) {
+            uint32_t orderSeq = [[WKSDK shared].chatManager getOrderSeq:firstUnreadSeq];
+            if (orderSeq > 0) {
+                self.messageListView.browseToOrderSeq = orderSeq;
+                keepOrderSeq = orderSeq;
+                keepOffSetY = -120.0f;
+            }
+        }
     }
     BOOL useKeep = false; // 是否使用保持的位置
     if(self.currentConversation.remoteExtra.keepMessageSeq>0) { // 有保持位置
@@ -418,7 +436,7 @@
     if(keepOrderSeq>0) {
         self.messageListView.keepPosition =  [WKConversationPosition orderSeq:keepOrderSeq offset:(int)keepOffSetY];
     }
-    
+
     if(self.locationAtOrderSeq!=0) { // 传过来的定位orderSeq最优先
         CGFloat offset = -self.input.lim_height - 40.0f;
         self.messageListView.needPositionReminder = true;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
@@ -429,7 +429,13 @@
     BOOL useKeep = false; // 是否使用保持的位置
     if(self.currentConversation.remoteExtra.keepMessageSeq>0) { // 有保持位置
         uint32_t kpOrderSeq = [[WKSDK shared].chatManager getOrderSeq:self.currentConversation.remoteExtra.keepMessageSeq];
-        if(keepOrderSeq == 0 || kpOrderSeq < keepOrderSeq) {
+        // 有未读 + 已经算出有效的 readBoundary 锚点 → 一律忽略 remoteExtra:
+        // 用户进会话时优先看到首条未读, 不应被"上次离开时的停留位置"覆盖到历史
+        // 消息位置 (微信式 UX; PR #33 后续反馈: 之前仍然定位到历史会话气泡)。
+        // 没未读 (newMsgCount==0) 或 readBoundary 路径失败 (keepOrderSeq==0):
+        // 仍用 remoteExtra 兜底, 保持上次停留位置 / 避免落到最底部, 行为不回归。
+        BOOL canOverride = (newMsgCount == 0) || (keepOrderSeq == 0);
+        if(canOverride && (keepOrderSeq == 0 || kpOrderSeq < keepOrderSeq)) {
             keepOrderSeq = kpOrderSeq;
             keepOffSetY = self.currentConversation.remoteExtra.keepOffsetY;
             useKeep = true;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
@@ -429,13 +429,18 @@
     BOOL useKeep = false; // 是否使用保持的位置
     if(self.currentConversation.remoteExtra.keepMessageSeq>0) { // 有保持位置
         uint32_t kpOrderSeq = [[WKSDK shared].chatManager getOrderSeq:self.currentConversation.remoteExtra.keepMessageSeq];
-        // 有未读 + 已经算出有效的 readBoundary 锚点 → 一律忽略 remoteExtra:
-        // 用户进会话时优先看到首条未读, 不应被"上次离开时的停留位置"覆盖到历史
-        // 消息位置 (微信式 UX; PR #33 后续反馈: 之前仍然定位到历史会话气泡)。
-        // 没未读 (newMsgCount==0) 或 readBoundary 路径失败 (keepOrderSeq==0):
-        // 仍用 remoteExtra 兜底, 保持上次停留位置 / 避免落到最底部, 行为不回归。
-        BOOL canOverride = (newMsgCount == 0) || (keepOrderSeq == 0);
-        if(canOverride && (keepOrderSeq == 0 || kpOrderSeq < keepOrderSeq)) {
+        // remoteExtra.keepMessageSeq 是"上次离开时滚动条所在位置", 用户可能在
+        // 读完最新消息后又往上翻到老消息位置才退出, remoteExtra 落在那条老消息上。
+        // 微信式 UX: 再进会话应回到"上次读到的位置"(= lastReadSeq → 通常即最新
+        // 消息位置), 而不是"上次翻看历史的停留位置"。
+        // 收紧 remoteExtra 兜底条件:
+        //   - 有未读 + readBoundary OK: 上面已锚定首条未读, 不用 remoteExtra
+        //   - 有未读 + readBoundary 失败 (lastReadSeq=0 又算不出兜底): 用
+        //     remoteExtra 避免 scrollToBottom 把未读划过去
+        //   - 无未读: 让 scrollToBottom 默认显示最新消息 (= 上次读到的位置),
+        //     不再用 remoteExtra "上次停留位置"覆盖 (用户反馈)。
+        BOOL canUseRemoteExtra = (newMsgCount > 0 && keepOrderSeq == 0);
+        if(canUseRemoteExtra) {
             keepOrderSeq = kpOrderSeq;
             keepOffSetY = self.currentConversation.remoteExtra.keepOffsetY;
             useKeep = true;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationView.m
@@ -399,21 +399,29 @@
     // 可能落到已删除消息 seq → getOrderSeq 返 0 → keepPosition 失效退化到最底部;
     // 子区/远端 reconcile race 也可能让 unreadCount 偏小, 同样退化。
     if(newMsgCount > 0 && conversationLastMessage) {
-        uint32_t firstUnreadSeq = 0;
         uint32_t lastReadSeq = [[WKUnreadStore shared] lastReadSeqForChannel:self.channel];
         uint32_t lastMsgSeq = [[WKSDK shared].chatManager getOrNearbyMessageSeq:conversationLastMessage.orderSeq];
+        // readBoundary = "最后一条已读" 的 seq:
+        //   - 首选 lastReadSeq (上次离开会话时精确写入, 不受撤回/删除/推送 race 影响)
+        //   - 兜底 lastMsgSeq - newMsgCount (与原算法语义完全对齐, lastReadSeq=0 时用)
+        uint32_t readBoundarySeq = 0;
         if (lastReadSeq > 0 && lastMsgSeq > lastReadSeq) {
-            // 首选: 上次离开会话时已确认读到 lastReadSeq, 下一条 (lastReadSeq+1) 就是首条未读
-            firstUnreadSeq = lastReadSeq + 1;
+            readBoundarySeq = lastReadSeq;
         } else if (lastMsgSeq > newMsgCount) {
-            // 兜底: 没有 lastReadSeq 时 (首次进/旧版本数据), 用 last - unread 近似
-            firstUnreadSeq = (uint32_t)(lastMsgSeq - newMsgCount + 1);
+            readBoundarySeq = (uint32_t)(lastMsgSeq - newMsgCount);
         }
-        if (firstUnreadSeq > 0) {
-            uint32_t orderSeq = [[WKSDK shared].chatManager getOrderSeq:firstUnreadSeq];
-            if (orderSeq > 0) {
-                self.messageListView.browseToOrderSeq = orderSeq;
-                keepOrderSeq = orderSeq;
+        if (readBoundarySeq > 0) {
+            uint32_t readBoundaryOrderSeq = [[WKSDK shared].chatManager getOrderSeq:readBoundarySeq];
+            if (readBoundaryOrderSeq > 0) {
+                // browseToOrderSeq 必须保持"已读边界"语义 (refreshNewMsgCount 用它算红点数,
+                // insertHistoryMsgSplitUI 在它之后插「以下是新消息」分割线), 不能换成
+                // 首条未读 seq, 否则红点偏小 1 + 首条未读被划成已读 (PR #33 R1 review)。
+                self.messageListView.browseToOrderSeq = readBoundaryOrderSeq;
+                // keepPosition 也锚定到 readBoundary (已读消息肯定 loaded, 不受撤回影响),
+                // 靠 offset = -120 把视口下推一行, 让首条未读 (readBoundary 下方) 自然
+                // 出现在视口顶部。即便首条未读 (lastReadSeq+1) 是撤回消息 indexPath 拿
+                // 不到, 也仍能命中 readBoundary 完成定位, 不退化到 scrollToBottom。
+                keepOrderSeq = readBoundaryOrderSeq;
                 keepOffSetY = -120.0f;
             }
         }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
@@ -18,27 +18,65 @@
     self.conversationPositionBarView = [[WKConversationPositionBarView alloc] init];
     __weak typeof(self) weakSelf = self;
     [self.conversationPositionBarView setOnScrollToBottom:^{
-        [weakSelf pullBottom];
+        __strong typeof(weakSelf) ws = weakSelf;
+        if (!ws) return;
+        // 微信式两步定位:
+        //   第 1 次 (有未读 + 视口未看到首条未读): 锚到首条未读, 让用户开始按时间
+        //     往下读, 不 mark read (用户还没看完);
+        //   第 2 次 (首条未读已在视口 / 没未读): 走原行为, pullBottom + 三端同步
+        //     mark read。
+        // 用「位置语义」自然区分一二次, 无状态 flag。
+        uint32_t firstUnreadOS = [ws ks_firstUnreadOrderSeqForScrollToBottom];
+        if (firstUnreadOS > 0 &&
+            ws.conversationPositionBarView.maxVisiableOrderSeq < firstUnreadOS) {
+            [ws locateMessageCellWithOrderSeqForReminder:firstUnreadOS
+                                           tablePosition:UITableViewScrollPositionTop];
+            return;
+        }
+        [ws pullBottom];
         // 「跑到最底部」按钮 = 用户主动声明「我都看完了」，必须显式做三端同步。
         // 不能复用 refreshNewMsgCount 的 oldMsgCount != newMsgCount 路径 —— 这条
         // 路径在 browseToOrderSeq=0 起步、newMsgCount 一直是 0 的场景会被 bypass，
         // 表现就是「视觉上 badge 消了，server 上 unread 没动，杀进程重启又复现」。
-        [weakSelf forceMarkAllAsRead];
+        [ws forceMarkAllAsRead];
     }];
     [self.conversationPositionBarView setOnScrollToPosition:^(WKConversationPosition * _Nonnull position,UITableViewScrollPosition tablePosition) {
         [weakSelf locateMessageCellWithOrderSeqForReminder:position.orderSeq tablePosition:tablePosition];
     }];
-    
-    
+
+
     [self addSubview:self.conversationPositionBarView];
-    
+
     NSArray<WKReminder*> *reminders = self.reminders;
     [self updateVisiableOrderSeq];
     [self.conversationPositionBarView updateReminders:reminders];
-    
+
     [self.conversationPositionBarView showScrollBottom:!self.positionAtBottom animateComplete:nil];
-    
+
     [self layoutConversationPositionBarView];
+}
+
+// 计算"首条未读"的 orderSeq, 用于向下按钮两步定位的第 1 步锚点。
+// 与 WKConversationView.calcKeepPositionAndBrowseToOrderSeq 同款算法:
+//   - 优先 lastReadSeq + 1 (精确, 不受撤回/删除/推送 race 影响)
+//   - 兜底 lastMsgSeq - newMsgCount + 1 (新会话 / 旧版数据 lastReadSeq=0 时用)
+// 没未读 / 计算失败时返 0, 调用方回退到原 pullBottom 行为。
+- (uint32_t)ks_firstUnreadOrderSeqForScrollToBottom {
+    if (self.newMsgCount <= 0) return 0;
+    WKChannel *ch = self.channel;
+    if (!ch) return 0;
+    uint32_t firstUnreadSeq = 0;
+    uint32_t lastReadSeq = [[WKUnreadStore shared] lastReadSeqForChannel:ch];
+    if (lastReadSeq > 0) {
+        firstUnreadSeq = lastReadSeq + 1;
+    } else if (self.lastMessage) {
+        uint32_t lastMsgSeq = self.lastMessage.messageSeq;
+        if (lastMsgSeq > (uint32_t)self.newMsgCount) {
+            firstUnreadSeq = lastMsgSeq - (uint32_t)self.newMsgCount + 1;
+        }
+    }
+    if (firstUnreadSeq == 0) return 0;
+    return [[WKSDK shared].chatManager getOrderSeq:firstUnreadSeq];
 }
 
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
@@ -21,17 +21,27 @@
         __strong typeof(weakSelf) ws = weakSelf;
         if (!ws) return;
         // 微信式两步定位:
-        //   第 1 次 (有未读 + 视口未看到首条未读): 锚到首条未读, 让用户开始按时间
-        //     往下读, 不 mark read (用户还没看完);
-        //   第 2 次 (首条未读已在视口 / 没未读): 走原行为, pullBottom + 三端同步
-        //     mark read。
-        // 用「位置语义」自然区分一二次, 无状态 flag。
+        //   第 1 次 (有未读 + 视口未看到首条未读 = 用户上翻了历史): 锚到 readBoundary,
+        //     让用户开始按时间往下读, 不 mark read (用户还没看完);
+        //   第 2 次 (首条未读已在视口 / 没未读 / 自然开会就已 anchor 到 readBoundary):
+        //     走原行为 pullBottom + 三端同步 mark read。
+        // 用「位置语义」(maxVisible vs firstUnread) 自然区分一二次, 无状态 flag。
+        //
+        // discriminator 用 firstUnread (lastReadSeq+1) 数值比较, 不依赖消息存在;
+        // anchor 用 readBoundary (lastReadSeq), 已读消息肯定 loaded — 即便首条
+        // 未读被撤回 indexPath 拿不到, readBoundary 仍能命中, 不会静默 no-op
+        // (R6 P2 / P1-2 选 C: 与 calcKeepPosition 同款 anchor)。
+        // tablePosition=Top 让 readBoundary 在视口顶, 首条未读出现在第二行,
+        // 视觉上等价于 calcKeepPosition 的 readBoundary + offset=-120。
         uint32_t firstUnreadOS = [ws ks_firstUnreadOrderSeqForScrollToBottom];
         if (firstUnreadOS > 0 &&
             ws.conversationPositionBarView.maxVisiableOrderSeq < firstUnreadOS) {
-            [ws locateMessageCellWithOrderSeqForReminder:firstUnreadOS
-                                           tablePosition:UITableViewScrollPositionTop];
-            return;
+            uint32_t readBoundaryOS = [ws ks_readBoundaryOrderSeqForScrollToBottom];
+            if (readBoundaryOS > 0) {
+                [ws locateMessageCellWithOrderSeqForReminder:readBoundaryOS
+                                               tablePosition:UITableViewScrollPositionTop];
+                return;
+            }
         }
         [ws pullBottom];
         // 「跑到最底部」按钮 = 用户主动声明「我都看完了」，必须显式做三端同步。
@@ -56,11 +66,11 @@
     [self layoutConversationPositionBarView];
 }
 
-// 计算"首条未读"的 orderSeq, 用于向下按钮两步定位的第 1 步锚点。
-// 与 WKConversationView.calcKeepPositionAndBrowseToOrderSeq 同款算法:
+// 计算"首条未读"的 orderSeq, 用于向下按钮两步定位的 discriminator (判断
+// 视口是否已包含首条未读)。是纯算术 getOrderSeq, 不需要消息真实存在。
+// 算法与 WKConversationView.calcKeepPositionAndBrowseToOrderSeq 同款:
 //   - 优先 lastReadSeq + 1 (精确, 不受撤回/删除/推送 race 影响)
 //   - 兜底 lastMsgSeq - newMsgCount + 1 (新会话 / 旧版数据 lastReadSeq=0 时用)
-// 没未读 / 计算失败时返 0, 调用方回退到原 pullBottom 行为。
 - (uint32_t)ks_firstUnreadOrderSeqForScrollToBottom {
     if (self.newMsgCount <= 0) return 0;
     WKChannel *ch = self.channel;
@@ -77,6 +87,28 @@
     }
     if (firstUnreadSeq == 0) return 0;
     return [[WKSDK shared].chatManager getOrderSeq:firstUnreadSeq];
+}
+
+// 计算"已读边界"的 orderSeq (= 首条未读 - 1), 用于向下按钮两步定位的实际
+// anchor 目标。比首条未读更鲁棒——已读消息肯定 loaded, 不会因为首条未读被
+// 撤回导致 indexPath 拿不到而 locateMessageCell 静默 no-op (R6 P2 / P1-2 选 C)。
+// 与 calcKeepPositionAndBrowseToOrderSeq 的 anchorSeq 同款逻辑。
+- (uint32_t)ks_readBoundaryOrderSeqForScrollToBottom {
+    if (self.newMsgCount <= 0) return 0;
+    WKChannel *ch = self.channel;
+    if (!ch) return 0;
+    uint32_t readBoundarySeq = 0;
+    uint32_t lastReadSeq = [[WKUnreadStore shared] lastReadSeqForChannel:ch];
+    if (lastReadSeq > 0) {
+        readBoundarySeq = lastReadSeq;
+    } else if (self.lastMessage) {
+        uint32_t lastMsgSeq = self.lastMessage.messageSeq;
+        if (lastMsgSeq > (uint32_t)self.newMsgCount) {
+            readBoundarySeq = (uint32_t)(lastMsgSeq - (uint32_t)self.newMsgCount);
+        }
+    }
+    if (readBoundarySeq == 0) return 0;
+    return [[WKSDK shared].chatManager getOrderSeq:readBoundarySeq];
 }
 
 


### PR DESCRIPTION
## Summary

类似微信，打开会话时自动定位到最早一条未读消息位置（向上是已读、向下是未读+最新），不再直接落到最底部最新消息。覆盖**群聊 / 私聊 / 子区 (`WK_COMMUNITY_TOPIC`)** 所有类型。

## 改动

`WKConversationView.calcKeepPositionAndBrowseToOrderSeq` 的算法切换。

**原算法**：`firstUnreadSeq = lastMessageSeq - unreadCount`

脆弱点：
- 群里有撤回/删除时 seq 不连续，算出的 seq 对应已删除消息 → `getOrderSeq:` 返 0 → `browseToOrderSeq=0` → `indexPathAtOrderSeq:0` 拿不到 → `handleLoadMessages` 走 `scrollToBottom` fallback，**直接落到最底部**
- 子区 / 远端 reconcile race 让 `unreadCount` 偏小时同样退化

**新算法**：`firstUnreadSeq = lastReadSeq + 1`

`lastReadSeq` 由 `viewWillDisappear` 时 `WKUnreadStore.markLocalRead:` 精确写入"已读到这里"。`+1` 必是首条未读，不受撤回/删除/推送 race 影响。

**兜底**：`lastReadSeq=0`（新会话 / 旧版数据）时回退到原 `lastMessageSeq - unreadCount` 算法，行为不回归。

## Test plan

- [ ] 群聊：往一个群发若干条消息，对方进群直接看到首条未读消息位置（不是最底部）
- [ ] 群里有撤回消息时仍能正确定位（不再退化到最底部）
- [ ] 私聊：同样行为
- [ ] 子区 (WK_COMMUNITY_TOPIC)：同样行为
- [ ] 新会话首次进入（lastReadSeq=0）：走兜底算法，行为同原版
- [ ] 单条未读：仍按原行为定位到该条
- [ ] 有 `remoteExtra.keepMessageSeq`（上次停留位置）时优先级仍正确
- [ ] 离开会话再进入：lastReadSeq 已更新，新消息从最新一条开始定位（如有）

🤖 Generated with [Claude Code](https://claude.com/claude-code)