### PR TITLE
fix: 频道查找 review 修复 · iPad/Bugly 多项崩溃兜底 · 气泡渲染/未读稳定性 · xls 预览

### DIFF
--- a/Modules/OctoContext/OctoContext/Classes/Cells/OctoSummaryActionSheet.m
+++ b/Modules/OctoContext/OctoContext/Classes/Cells/OctoSummaryActionSheet.m
@@ -43,6 +43,17 @@
     [sheet addAction:[UIAlertAction actionWithTitle:LLang(@"删除") style:UIAlertActionStyleDestructive
                                             handler:^(UIAlertAction *_) { if (onAction) onAction(OctoSummaryActionDelete); }]];
     [sheet addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    // iPad / Designed-for-iPad on Mac 上 actionSheet 走 popover, 必须有非 nil 的
+    // sourceView + sourceRect (或 barButtonItem), 否则 present 时抛
+    // NSGenericException: "UIPopoverPresentationController ... should have a
+    // non-nil sourceView or barButtonItem set before the presentation occurs.
+    // 手头拿不到触发按钮的引用, 兜底锚到 presenter.view 中心并去掉箭头。
+    if (sheet.popoverPresentationController) {
+        sheet.popoverPresentationController.sourceView = vc.view;
+        sheet.popoverPresentationController.sourceRect = CGRectMake(vc.view.bounds.size.width / 2,
+                                                                    vc.view.bounds.size.height / 2, 0, 0);
+        sheet.popoverPresentationController.permittedArrowDirections = 0;
+    }
     [vc presentViewController:sheet animated:YES completion:nil];
 }
 

--- a/Modules/OctoContext/OctoContext/Classes/Public/OctoSummaryListVC.m
+++ b/Modules/OctoContext/OctoContext/Classes/Public/OctoSummaryListVC.m
@@ -697,6 +697,14 @@
         [self confirmDelete:item];
     }]];
     [sheet addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    // iPad 上 actionSheet 走 popover, 需要非 nil 的 sourceView + sourceRect。
+    // 这条 sheet 目前是 UIMenu 兼容兜底路径, 无触发按钮引用, 锚到 self.view 中心。
+    if (sheet.popoverPresentationController) {
+        sheet.popoverPresentationController.sourceView = self.view;
+        sheet.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width / 2,
+                                                                    self.view.bounds.size.height / 2, 0, 0);
+        sheet.popoverPresentationController.permittedArrowDirections = 0;
+    }
     [self presentViewController:sheet animated:YES completion:nil];
 }
 

--- a/Modules/WuKongBase/WuKongBase/Assets/Lang/en.lproj/Localizable.strings
+++ b/Modules/WuKongBase/WuKongBase/Assets/Lang/en.lproj/Localizable.strings
@@ -757,6 +757,76 @@
 // 列表中的硬写文案 LLang 化后所需翻译
 "正在加载空间列表..."="Loading spaces...";
 "请等待连接成功后再切换空间"="Wait until connected before switching spaces";
+
+// ===== Channel history search (ChannelHistorySearch/) — 与 web ChannelSearchPanel 对齐 =====
+// "查找聊天内容" 已在 line 623 翻译，不重复
+"搜索聊天记录"="Search messages";
+"全部"="All";
+"图片视频"="Photos & Videos";
+"图片和视频暂不支持按关键词搜索，可按发送人或日期查找"="Photos and videos can't be searched by keyword — filter by sender or date instead.";
+"关键词最多 %ld 个字"="Keyword can't exceed %ld characters";
+"加载更多失败，请重试"="Failed to load more — please retry";
+"无法定位到该消息"="Can't jump to this message";
+"发送人: %ld"="Senders: %ld";
+"时间正序"="Oldest first";
+"最早"="Earliest";
+"至今"="Now";
+// EmptyView
+"输入关键词查找此聊天内的记录"="Type a keyword to search this chat";
+"未找到相关内容"="No matches";
+"换个关键词或调整筛选条件再试试"="Try a different keyword or adjust filters";
+"搜索中…"="Searching…";
+"加载失败"="Loading failed";
+"请检查网络后重试"="Please check your network and try again";
+"当前网络不可用"="No internet connection";
+"请检查网络设置"="Please check network settings";
+"点击重试"="Tap to retry";
+// Message cell
+"共 %ld 条记录"="%ld messages";
+// Media row cell
+"视频"="Video";
+"图片"="Image";
+// Filter VC
+"选择发送人"="Choose senders";
+"搜索成员"="Search members";
+"最多选择 50 人"="Up to 50 people";
+"重置"="Reset";
+"应用"="Apply";
+"发送人"="Sender";
+"日期范围"="Date range";
+"排序"="Sort";
+"全部成员"="All members";
+"已选 %ld 人"="%ld selected";
+"起始日期"="Start date";
+"结束日期"="End date";
+"不限"="Any";
+"快速选择"="Presets";
+"今天 / 7 天 / 30 天 / 全部"="Today / 7d / 30d / All";
+"时间倒序（最新在前）"="Newest first";
+"时间正序（最早在前）"="Oldest first";
+"今天"="Today";
+"最近 7 天"="Last 7 days";
+"最近 30 天"="Last 30 days";
+"全部时间"="All time";
+"清除"="Clear";
+
+// Preview (media browser + file preview)
+"定位到聊天位置"="Jump to chat";
+"保存图片到相册"="Save image to Photos";
+"保存视频到相册"="Save video to Photos";
+"保存文件"="Save file";
+"文件链接不可用"="File link unavailable";
+"下载中…"="Downloading…";
+"文件下载失败"="Download failed";
+"已保存"="Saved";
+"文件不可用"="File unavailable";
+
+// Forward card in message cell
+"转发聊天记录含\"%@\""="Forwarded messages contain \"%@\"";
+"转发聊天记录"="Forwarded messages";
+"%ld条聊天记录"="%ld messages";
+"还有 %ld 条聊天记录"="+ %ld more";
+"[视频]"="[Video]";
 "%@/#子区"="%@/#thread";
 
 // ============================================================

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKVideoBrowserData.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKVideoBrowserData.h
@@ -21,12 +21,16 @@ typedef void(^downloadProgressBlock)(CGFloat progress);
 
 
 @property(nonatomic,copy) downloadCallback download;
-// 封面图
-@property(nonatomic,weak) UIImage *coverImage;
+// 封面图 (strong - 浏览器在 setYb_cellData: 中读取后才会拷给 imageView, 期间需要保活;
+// 历史上是 weak 但当时无消费方, 不构成行为变更)
+@property(nonatomic,strong) UIImage *coverImage;
 
 @property(nonatomic,copy) downloadProgressBlock progress;
 
-
+/// 自定义业务数据 (与 YBIBImageData.extraData 同语义)。
+/// 例: 搜索结果浏览器把当前命中项放在 extraData[@"channelHistoryItem"] 里, 供 toolbar
+/// 在「定位到聊天位置」时取回上下文使用。
+@property(nonatomic,strong,nullable) id extraData;
 
 @end
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Input/FuncGroup/WKPanelDefaultFuncItem.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Input/FuncGroup/WKPanelDefaultFuncItem.m
@@ -193,6 +193,13 @@
     vc.conversationContext = self.inputPanel.conversationContext;
     vc.modalPresentationStyle = UIModalPresentationPopover;
 //    UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:vc];
+    // iPad 上 modalPresentationStyle = Popover 时 popoverPresentationController 需要
+    // 非 nil 的 sourceView (+ sourceRect) 或 barButtonItem, 否则 present 抛 NSGenericException。
+    // 触发是"更多"按钮 btn, 直接锚到它。iPhone 上 popover 自动适配到全屏, 设置 sourceView 无副作用。
+    if (vc.popoverPresentationController && btn) {
+        vc.popoverPresentationController.sourceView = btn;
+        vc.popoverPresentationController.sourceRect = btn.bounds;
+    }
     [[WKNavigationManager shared].topViewController presentViewController:vc animated:YES completion:nil];
 }
 - (NSString *)title {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Input/WKHoldToTalkManager.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/Input/WKHoldToTalkManager.m
@@ -1209,7 +1209,19 @@ static CGFloat const kMaxTextViewHeight = 15 * 20.0; // 15 lines * ~20pt line he
     NSString *appleT = [current isEqualToString:kVoiceAPIApple] ? @"✓ Apple引擎" : @"Apple引擎";
     [sheet addAction:[UIAlertAction actionWithTitle:appleT style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { [self setAPIPreference:kVoiceAPIApple]; }]];
     [sheet addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
-    [[WKNavigationManager shared].topViewController presentViewController:sheet animated:YES completion:nil];
+    // iPad 上 actionSheet 走 popover, 必须有非 nil 的 sourceView + sourceRect,
+    // 否则 present 时抛 NSGenericException。锚到触发按钮; 拿不到按钮时兜底 top vc 视图中心。
+    UIViewController *topVC = [WKNavigationManager shared].topViewController;
+    if (sheet.popoverPresentationController) {
+        UIView *anchor = self.apiSwitchBtn ?: topVC.view;
+        sheet.popoverPresentationController.sourceView = anchor;
+        sheet.popoverPresentationController.sourceRect = CGRectMake(anchor.bounds.size.width / 2,
+                                                                    anchor.bounds.size.height / 2, 0, 0);
+        sheet.popoverPresentationController.permittedArrowDirections = self.apiSwitchBtn
+            ? UIPopoverArrowDirectionAny
+            : 0;
+    }
+    [topVC presentViewController:sheet animated:YES completion:nil];
 }
 
 #pragma mark - Waveform

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationWrapModel.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationWrapModel.h
@@ -103,6 +103,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic,strong) NSArray<WKReminder*> *simpleReminders;
 
+/// 最近 tab 视角下的「活动未读」= 主群未读 + 最新子区未读。
+/// - 与 -lastMsgTimestamp / -content / -spaceFilteredLastMessage 同源：这几个都
+///   走 lastChildConversation 反映最新一条消息；unread 只读 self.c.unreadCount
+///   会漏掉子区消息带来的未读，用户视角是「预览时间对但红点不亮」（长时间后台后
+///   突然收到子区消息尤其明显）。
+/// - **仅用于最近 tab 里父群行 cell 的 badge 显示**。关注 tab 里父群 group-summary
+///   badge 依然走 unreadCount（只反映主群自身），因为那边子区在 threadToggle /
+///   groupThread 上有独立 indicator/胶囊；双算会重复计数。
+/// - Tab 底部总未读 / follow section header / recent 汇总里 `count += m.unreadCount`
+///   的地方 **不要** 用这个 getter：子区在 threadWrapModels 里已被独立累加，父群
+///   再 fold 一次会重复。
+@property(nonatomic,assign,readonly) NSInteger recentTabActivityUnreadCount;
+
 /**
  扩展数据
  */

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationWrapModel.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKConversationWrapModel.m
@@ -226,6 +226,20 @@
     self.c.unreadCount = unreadCount;
 }
 
+- (NSInteger)recentTabActivityUnreadCount {
+    // 与 -lastMsgTimestamp / -content 同源：最近 tab 父群行的预览时间/内容读
+    // lastChildConversation，unread 也把这一路 fold 进来，避免 app 长时间后台后
+    // 收到子区消息时出现「时间对但红点不亮」（bug repro：锁屏久挂后子区推送到达）。
+    // 只 fold 「最新一个」子区，不遍历 children —— 与 lastMsgTimestamp getter 的
+    // 观察窗口保持一致；tab 底部汇总 / follow section header 走独立累加路径,
+    // 不复用此 getter（详见 .h 注释）。
+    NSInteger own = self.c.unreadCount;
+    if (self.lastChildConversation) {
+        own += self.lastChildConversation.unreadCount;
+    }
+    return own;
+}
+
 /// 判断是否需要按空间过滤最后一条消息（所有个人聊天在多空间模式下都需要）
 -(BOOL) isSystemBotChannel {
     if(self.c.channel.channelType != WK_PERSON) {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListDataProviderImp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListDataProviderImp.m
@@ -396,6 +396,37 @@
 -(void) pullDownRecursive:(uint32_t)startOrderSeq accumulated:(NSMutableArray<WKMessageModel*>*)accumulated existingIds:(NSMutableSet*)existingIds complete:(void(^)(bool more))complete {
     NSInteger pageLimit = [WKApp shared].config.eachPageMsgLimit;
     __weak typeof(self) weakSelf = self;
+
+    // 关键: pulldown 必须传 endOrderSeq 把查询严格收紧在「dpHead 往下一个连续窗口」内。
+    //
+    // 历史上用的 pullDown:startOrderSeq:limit: (= pullMessages 但 endOrderSeq=0 无下界)
+    // 会让 SDK 在 local DB 里查「WHERE orderSeq < startOrderSeq ORDER BY DESC LIMIT N」,
+    // 命中之前浏览历史时缓存的远古条目, 跟 dpHead 之间可能隔几千 / 上万 messageSeq 没人补。
+    // 经典复现路径:
+    //   1) 用户跳到某条 reminder 读历史 (dp 围绕 orderSeq~17K, local 缓存了 13K..72K 段)
+    //   2) 锁屏期间群里新增大量消息 (server 端 lastMsg=2333K, local DB 大概率也同步进来一些
+    //      碎片段 [191K..220K] 等, 但没有 [221K..2303K] 这块桥接)
+    //   3) 解锁点跳转最新 → pullFirst:nil → dp reset 到 [2304K..2333K]
+    //   4) 用户上滑 → pulldown(startOrderSeq=2304K, endOrderSeq=0) → SDK 命中 local DB
+    //      [191K..220K] 段直接 prepend → dp 变成 [191K..220K, 2304K..2333K] **非连续**
+    //      → UIKit cell 复用 / 日期 section / scroll offset 全错位 → 气泡损坏
+    //
+    // 修复后: 传入窗口下界 endOrderSeq = startOrderSeq - pageLimit × WKOrderSeqFactor × 10。
+    //   - 30 条消息正常 span = 30 × 1000 = 30K orderSeq, 10× slack 给删除 / 空隙 = 300K 上限,
+    //     任何活跃度的群够用 (实际死群更稀疏, 活跃群 messageSeq 是密集的)
+    //   - local DB 在窗口内若有数据: 直接返回 → 跟当前 dpHead 连续的相邻 30 条 (正常 case)
+    //   - local DB 在窗口内若空: SDK 内部 calSync 自动到 server 拉这段 → sync 进 local DB
+    //     → 递归 pullMessages 再查一次 → 拿到桥接消息 (经典 reset-load 后第一次 pulldown)
+    //   - 用户继续上滑: dpHead 移到刚回来的最老一条, 下次 pulldown 窗口下移, 继续按页 sync
+    //
+    // 不丢任何历史: 远古消息只是按需 + 连续地拉, 不再可能一次 prepend 跳进非连续区间。
+    // 跟微信下滑读历史的语义对齐 — 上滑一页 = 当前位置往下相邻一页, 不会突然跳到三个月前。
+    uint32_t endOrderSeq = 0;
+    if (startOrderSeq > 0) {
+        uint64_t bound = (uint64_t)pageLimit * (uint64_t)WKOrderSeqFactor * 10ull;
+        endOrderSeq = (startOrderSeq > (uint32_t)bound) ? (startOrderSeq - (uint32_t)bound) : 1;
+    }
+
     // 串到 ioQueue：SDK 本地 DB 读不再卡 main；递归调用也走 ioQueue，串行队列保证补窗顺序。
     dispatch_async(self.ioQueue, ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -405,8 +436,15 @@
             }
             return;
         }
-        [[WKSDK shared].chatManager pullDown:strongSelf.channel startOrderSeq:startOrderSeq limit:(int)pageLimit complete:^(NSArray<WKMessage *> * _Nonnull messages, NSError * _Nonnull error) {
+        [[WKSDK shared].chatManager pullMessages:strongSelf.channel
+                                   startOrderSeq:startOrderSeq
+                                     endOrderSeq:endOrderSeq
+                                           limit:(int)pageLimit
+                                        pullMode:WKPullModeDown
+                                        complete:^(NSArray<WKMessage *> * _Nonnull messages, NSError * _Nonnull error) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                NSLog(@"[BubbleBugRepro] dp.pullDown SDK RETURN start=%u end=%u msgs=%lu err=%@",
+                      startOrderSeq, endOrderSeq, (unsigned long)messages.count, error.localizedDescription ?: @"nil");
                 if (error || !messages || messages.count == 0) {
                     if (accumulated.count > 0) {
                         [weakSelf handleMessages:accumulated insertFirst:YES complete:complete];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListDataProviderImp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListDataProviderImp.m
@@ -443,8 +443,10 @@
                                         pullMode:WKPullModeDown
                                         complete:^(NSArray<WKMessage *> * _Nonnull messages, NSError * _Nonnull error) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                #if DEBUG
                 NSLog(@"[BubbleBugRepro] dp.pullDown SDK RETURN start=%u end=%u msgs=%lu err=%@",
                       startOrderSeq, endOrderSeq, (unsigned long)messages.count, error.localizedDescription ?: @"nil");
+                #endif
                 if (error || !messages || messages.count == 0) {
                     if (accumulated.count > 0) {
                         [weakSelf handleMessages:accumulated insertFirst:YES complete:complete];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView+Position.m
@@ -120,10 +120,12 @@
                               && minVisiableOrderSeq != 0
                               && [[WKSDK shared].chatManager getOrderSeq:reminder.messageSeq] >= minVisiableOrderSeq
                               && [[WKSDK shared].chatManager getOrderSeq:reminder.messageSeq] <= maxVisiableOrderSeq);
+            #if DEBUG
             NSLog(@"[ReminderTrace] orphan-check channelId=%@ reminderID=%lld msgSeq=%u localMsgExists=%d localMsgIsDeleted=%d inVisibleRange=%d minVisOrder=%u maxVisOrder=%u",
                   reminder.channel.channelId, reminder.reminderID, reminder.messageSeq,
                   msg != nil, msg ? (int)msg.isDeleted : -1, inVisible,
                   minVisiableOrderSeq, maxVisiableOrderSeq);
+            #endif
         }
     }
 }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -97,6 +97,22 @@ static const BOOL kIncrementalPulldown = NO;
 // reloadData + scrollToBottom 触发离屏 layout 但 willDisplayCell: 没回调, refresh: 永不跑
 // → 回前台 cell 内容空白" 的回归。设置点: handleRecvMessage 后台分支 + onConversationSyncFinished。
 @property(nonatomic,assign) BOOL dirtyAfterBackground;
+// reconcile 防抖: 同一回前台动作会同时派发 UIApplicationWillEnterForeground /
+// UIApplicationDidBecomeActive / UISceneWillEnterForeground / UISceneDidActivate
+// 多条通知, 全部 hook 到本对账方法。500ms 内重复触发跳过, 避免连刷 reloadData
+// 抢主线程导致回前台首帧卡顿。注意: 防抖放在所有 gate 之后, gate 命中而早退
+// 时不更新时间戳, 后到的通知仍能补一次, 不损失对账机会。
+@property(nonatomic,assign) NSTimeInterval reconcileLastTs;
+// pendingReconcile: gate 命中 (isPulldownInProgress / isRehydrating / pullupHasMore)
+// 时, dirtyAfterBackground 不被消费, 同时 pending 置位; gate 清掉的路径 (pulldown
+// 完成 / rehydrate finish) 末尾调 wk_tryConsumePendingReconcile, 异步派发一次
+// reconcile 补刷。
+//
+// 没有这条机制时, 用户在看历史 (pullupHasMore=YES) / 重连补齐期间 (isRehydrating)
+// 锁屏复活就会落入空窗: 回前台时三条通知派发 reconcile, 全被 gate 拒掉, 等
+// gate 自然清掉时已经无人再触发 reconcile, 后台离屏 insert 的 cell 就永久空白
+// 必须退出重进。
+@property(nonatomic,assign) BOOL pendingReconcile;
 // 跟踪上一次连接状态: 只在 (非 Connected → Connected) 跳变时触发 rehydrate,
 // 否则连续 ping/pong 都会重复跑。
 @property(nonatomic,assign) WKConnectStatus prevConnectStatus;
@@ -238,8 +254,20 @@ static const BOOL kIncrementalPulldown = NO;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onShareExtensionMessageSent:) name:@"WKShareExtensionMessageSent" object:nil];
     // 多选模式下 cell 圆圈被勾选时刷新 anchor
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onMultipleAnchorDidChange:) name:@"WKMessageMultipleAnchorDidChange" object:nil];
-    // 回前台对账：修后台收消息离屏 insert 致最新消息行空白（见 onAppDidBecomeActiveReconcile:）
+    // 回前台对账：修后台收消息离屏 insert 致最新消息行空白（见 onAppDidBecomeActiveReconcile:）。
+    //
+    // 监听 4 路通知, 任一触发都跑一次对账, 用 reconcileLastTs 500ms 防抖去重。
+    // 旧实现只挂 UIApplicationDidBecomeActiveNotification, 在 iPadOS 多场景 /
+    // iOS 13+ scene lifecycle 下有些回前台路径根本不派发该通知 (例如多窗口
+    // app 中某个 scene 单独被 resume), 导致对账 hook 永远不响应、cell 内容空白
+    // 必须退出重进才能修。Will* 系列比 Did* 系列早一帧, 让 reloadData 在 UIKit
+    // 真正开始渲染前完成, 视觉上更顺。
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActiveReconcile:) name:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActiveReconcile:) name:UIApplicationWillEnterForegroundNotification object:nil];
+    if (@available(iOS 13.0, *)) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActiveReconcile:) name:UISceneDidActivateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onAppDidBecomeActiveReconcile:) name:UISceneWillEnterForegroundNotification object:nil];
+    }
 }
 
 -(void) removeDelegates {
@@ -258,6 +286,11 @@ static const BOOL kIncrementalPulldown = NO;
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"WKShareExtensionMessageSent" object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"WKMessageMultipleAnchorDidChange" object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+    if (@available(iOS 13.0, *)) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UISceneDidActivateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UISceneWillEnterForegroundNotification object:nil];
+    }
 }
 
 /// 外部分享的消息发送后，插入消息到当前聊天页面
@@ -453,12 +486,25 @@ static const BOOL kIncrementalPulldown = NO;
 
 -(void) loadMessages:(BOOL)animation firstLoad:(BOOL)firstLoad complete:(void(^)(void))complete{
     __weak typeof(self) weakSelf = self;
+    WKMessageModel *_dpHeadBefore = [self.dataProvider firstMessage];
+    WKMessageModel *_dpTailBefore = [self.dataProvider lastMessage];
+    NSLog(@"[BubbleBugRepro] loadMessages ENTRY animation=%d firstLoad=%d keepPos=%u dpHead=%u dpTail=%u dpCount=date×%lu",
+          animation, firstLoad,
+          self.keepPosition.orderSeq,
+          _dpHeadBefore.orderSeq, _dpTailBefore.orderSeq,
+          (unsigned long)self.dataProvider.dates.count);
     if(self.keepPosition) {
         [self enablePullup:YES];
     }else {
         [self enablePullup:NO];
     }
     [self.dataProvider pullFirst:self.keepPosition complete:^(bool hasMore) {
+        WKMessageModel *_dpHeadAfter = [weakSelf.dataProvider firstMessage];
+        WKMessageModel *_dpTailAfter = [weakSelf.dataProvider lastMessage];
+        NSLog(@"[BubbleBugRepro] loadMessages pullFirst RETURN hasMore=%d dpHead=%u dpTail=%u dpDates=%lu",
+              hasMore,
+              _dpHeadAfter.orderSeq, _dpTailAfter.orderSeq,
+              (unsigned long)weakSelf.dataProvider.dates.count);
         [weakSelf handleLoadMessages:animation firstLoad:firstLoad hasMore:hasMore complete:complete];
     }];
 }
@@ -560,15 +606,23 @@ static const BOOL kIncrementalPulldown = NO;
 
 // 请求到最底部
 -(void) pullBottom {
+    WKMessageModel *_dpHead = [self.dataProvider firstMessage];
+    WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+    NSLog(@"[BubbleBugRepro] pullBottom ENTRY pullupHasMore=%d positionAtBottom=%d dpHead=%u dpTail=%u lastMsg=%u appState=%ld",
+          [self pullupHasMore], self.positionAtBottom,
+          _dpHead.orderSeq, _dpTail.orderSeq, self.lastMessage.orderSeq,
+          (long)[UIApplication sharedApplication].applicationState);
     if(![self pullupHasMore]) {
+        NSLog(@"[BubbleBugRepro] pullBottom PATH=scroll-only (already at bottom in dp)");
         [self pullupFinished];
         [self.tableView setContentOffset:self.tableView.contentOffset animated:NO]; // 立刻停止滚动
         [self scrollToBottom:YES];
         return;
     }
+    NSLog(@"[BubbleBugRepro] pullBottom PATH=reset-load (pullupHasMore=YES) — will pullFirst:nil");
     self.keepPosition = nil;
     [self loadMessages:true firstLoad:false complete:nil];
-  
+
 }
 
 - (void)suppressScrollOnce {
@@ -759,6 +813,13 @@ static const BOOL kIncrementalPulldown = NO;
     }
 
     __weak typeof(self) weakSelf = self;
+    {
+        WKMessageModel *_dpHead = [self.dataProvider firstMessage];
+        WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        NSLog(@"[BubbleBugRepro] pulldown ENTRY dpHead=%u dpTail=%u dpDates=%lu positionAtBottom=%d",
+              _dpHead.orderSeq, _dpTail.orderSeq,
+              (unsigned long)self.dataProvider.dates.count, self.positionAtBottom);
+    }
     WK_PERF_LOG(@"[PullDebug] pulldown START, mj_header.state=%ld, isPulldownInProgress=%d", (long)self.tableView.mj_header.state, self.isPulldownInProgress);
 
     // 标记 pulldown 进行中，阻止新消息并发修改 tableView
@@ -928,14 +989,30 @@ static const BOOL kIncrementalPulldown = NO;
                     [weakSelf.tableView.mj_header endRefreshing];
                     weakSelf.isPulldownInProgress = NO;
                     WK_PERF_LOG(@"[PullDebug] pulldown: COMPLETE (hasInsertions path), mj_header.state=%ld", (long)weakSelf.tableView.mj_header.state);
+                    {
+                        WKMessageModel *_dpHead = [weakSelf.dataProvider firstMessage];
+                        WKMessageModel *_dpTail = [weakSelf.dataProvider lastMessage];
+                        NSLog(@"[BubbleBugRepro] pulldown DONE path=hasInsertions newMsgs=%lu dpHead=%u dpTail=%u dpDates=%lu",
+                              (unsigned long)newMsgs.count, _dpHead.orderSeq, _dpTail.orderSeq,
+                              (unsigned long)weakSelf.dataProvider.dates.count);
+                    }
                     [weakSelf processPendingRecvMessages];
+                    [weakSelf wk_tryConsumePendingReconcile];
                 });
             });
         } else {
             [weakSelf.tableView.mj_header endRefreshing];
             weakSelf.isPulldownInProgress = NO;
             WK_PERF_LOG(@"[PullDebug] pulldown: COMPLETE (no insertions), mj_header.state=%ld", (long)weakSelf.tableView.mj_header.state);
+            {
+                WKMessageModel *_dpHead = [weakSelf.dataProvider firstMessage];
+                WKMessageModel *_dpTail = [weakSelf.dataProvider lastMessage];
+                NSLog(@"[BubbleBugRepro] pulldown DONE path=noInsertions dpHead=%u dpTail=%u dpDates=%lu",
+                      _dpHead.orderSeq, _dpTail.orderSeq,
+                      (unsigned long)weakSelf.dataProvider.dates.count);
+            }
             [weakSelf processPendingRecvMessages];
+            [weakSelf wk_tryConsumePendingReconcile];
         }
     }];
 
@@ -1050,6 +1127,11 @@ static const NSInteger kMaxPullupDedupRetry = 3;
                     WK_PERF_LOG(@"[PullDebug] pullup: COMPLETE (hasData path), mj_footer.state=%ld", (long)weakSelf.tableView.mj_footer.state);
                     if(complete) {
                         complete(hasMore);
+                    }
+                    // gate-clear 接力: 用户上滑读历史 + 锁屏复活时 reconcile 被
+                    // pullupHasMore 拦下, 这里 pullup 跑完(hasMore=NO 即已到底)再补一次。
+                    if (!hasMore) {
+                        [weakSelf wk_tryConsumePendingReconcile];
                     }
                 });
             });
@@ -2039,7 +2121,16 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         self.hasRecvMsg = true;
     }
     WKMessageModel *messageModel = [[WKMessageModel alloc] initWithMessage:message];
+    {
+        WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        NSLog(@"[BubbleBugRepro] handleRecvMessage ENTRY msgNo=%@ msgOrderSeq=%u dpTail=%u lastMsg=%u pullupHasMore=%d positionAtBottom=%d appState=%ld",
+              message.clientMsgNo, messageModel.orderSeq,
+              _dpTail.orderSeq, self.lastMessage.orderSeq,
+              [self pullupHasMore], self.positionAtBottom,
+              (long)[UIApplication sharedApplication].applicationState);
+    }
     if([self pullupHasMore]) { // 消息没有完全加载完成
+        NSLog(@"[BubbleBugRepro] handleRecvMessage PATH=pullupHasMore (only updateLastMsgIfNeed) — NEW MSG DROPPED FROM DP");
         [self updateLastMsgIfNeed:messageModel];
         if( [message isSend]) {
             [self  pullBottom];
@@ -2062,6 +2153,8 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         //   相等判断提前 return，永远不会补一次 reloadData。reloadData 是惰性的，回前台下次
         //   layout 会重查 numberOfRows 并重新 willDisplayCell:，自愈（对齐 git-init 的原行为）。
         if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+            NSLog(@"[BubbleBugRepro] handleRecvMessage PATH=background msgOrderSeq=%u dpTail=%u (no gap-fill in bg branch)",
+                  messageModel.orderSeq, [self.dataProvider lastMessage].orderSeq);
             // R4 fix: 标记 "回前台 reconcile 时即使 numberOfRows 一致也要强制 reloadData 一次",
             // 治后台 reloadData + scrollToBottom 触发离屏 layout 但 willDisplayCell: 没回调,
             // 回前台 UIKit 误判 "已布局" 不重渲染、cell 内容空白的回归。消费点:
@@ -3053,6 +3146,9 @@ static const NSInteger kMaxRehydratePages = 35;
         [self drainPendingRecvMessagesAfterRehydrate];
     }
 
+    // gate-clear 接力: 回前台对账时若卡在 isRehydrating 早退, 这里走完后补一次。
+    [self wk_tryConsumePendingReconcile];
+
     // capped HUD 也只在仍属活跃显示页时弹, 避免 VC 已被 push 盖住但还没 detach
     // (e.g. push 资料页期间 watchdog 触发) 时把 HUD 弹到无关页面。
     if (capped && self.window) {
@@ -3148,6 +3244,8 @@ static const NSInteger kMaxRehydratePages = 35;
             if (!ss.isPulldownInProgress) {
                 [ss drainPendingRecvMessagesAfterRehydrate];
             }
+            // gate-clear 接力: 回前台对账时若卡在 isRehydrating 早退, 这里走完后补一次。
+            [ss wk_tryConsumePendingReconcile];
         });
     }];
 }
@@ -3163,15 +3261,41 @@ static const NSInteger kMaxRehydratePages = 35;
     if (!self.channel) {
         return;
     }
-    if (self.isPulldownInProgress) { // 不和进行中的 pulldown 抢 tableView
+    NSLog(@"[BubbleBugRepro] reconcile ENTRY note=%@ dirty=%d pending=%d pulldown=%d rehydrate=%d pullupMore=%d posAtBottom=%d",
+          note.name ?: @"(consume)",
+          self.dirtyAfterBackground, self.pendingReconcile,
+          self.isPulldownInProgress, self.isRehydrating,
+          [self pullupHasMore], self.positionAtBottom);
+    // gate 命中早退路径: dirtyAfterBackground 仍为 YES (说明后台真的动过状态、
+    // 需要补刷) 时把 pendingReconcile 置位, 等 gate 清掉的回调路径再调
+    // wk_tryConsumePendingReconcile 补一次。覆盖三种场景:
+    //   - 用户上滑读历史时锁屏复活 (pullupHasMore=YES)
+    //   - 重连补齐期间锁屏复活 (isRehydrating=YES)
+    //   - pulldown 跑着的时候锁屏复活 (isPulldownInProgress=YES)
+    // 不持锁不抢 tableView, 安全。
+    if (self.isPulldownInProgress) {
+        if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        NSLog(@"[BubbleBugRepro] reconcile GATE=isPulldownInProgress pendingNow=%d", self.pendingReconcile);
         return;
     }
-    if (self.isRehydrating) { // 重连补齐 / orderSeq gap fill 在跑, 让它自己收尾
+    if (self.isRehydrating) {
+        if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        NSLog(@"[BubbleBugRepro] reconcile GATE=isRehydrating pendingNow=%d", self.pendingReconcile);
         return;
     }
-    if ([self pullupHasMore]) { // 用户上滑在看历史，reload 会跳位，放过
+    if ([self pullupHasMore]) {
+        if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        NSLog(@"[BubbleBugRepro] reconcile GATE=pullupHasMore pendingNow=%d", self.pendingReconcile);
         return;
     }
+    // 防抖: gate 全部放行后再判, 这样 gate 命中早退不会污染时间戳, 下条通知仍能
+    // 补一次。同一回前台动作 (Will*+Did*+SceneWill*+SceneDidActive) 半秒内只跑一次
+    // reloadData, 避免连刷抢主线程影响首帧丝滑。
+    NSTimeInterval _reconcileNow = CFAbsoluteTimeGetCurrent();
+    if (_reconcileNow - self.reconcileLastTs < 0.5) {
+        return;
+    }
+    self.reconcileLastTs = _reconcileNow;
     WKMessageModel *dpLast = [self.dataProvider lastMessage];
     if (!dpLast) {
         return;
@@ -3212,11 +3336,36 @@ static const NSInteger kMaxRehydratePages = 35;
     }
 
     if (needsReload) {
+        NSLog(@"[BubbleBugRepro] reconcile RELOAD dirty=%d positionAtBottom=%d", dirty, self.positionAtBottom);
         [self.tableView reloadData];
         if (self.positionAtBottom) {
             [self scrollToBottom:NO];
         }
+    } else {
+        NSLog(@"[BubbleBugRepro] reconcile NOOP (no signals)");
     }
+    // 真的跑到这里说明 reconcile 主路径已经走过 (或 cheap-path 确认 UI 状态干净),
+    // pendingReconcile 就此清掉避免后续 gate-clear 路径无谓再补一次。
+    self.pendingReconcile = NO;
+}
+
+// gate (pulldown / rehydrate) 清掉后的统一接力点: 若 pending 立位则异步派发一次
+// reconcile 重跑。异步避开当前调用栈 (pulldown / rehydrate 完成的回调内部还在
+// 持续操作 tableView, reload 嵌套进去会跟 batchUpdates / scroll-to-bottom 抢
+// 主线程), 让本帧 UI 先稳定下来再补刷, 保持丝滑。
+//
+// 防抖时间戳由 reconcile 自己维护, 这里不动 — 接力补刷应当不受 500ms 防抖影响
+// (前一次 reconcile 是 gate 命中直接早退, 没动时间戳, 这次能真正跑进主路径)。
+-(void) wk_tryConsumePendingReconcile {
+    if (!self.pendingReconcile) return;
+    if (!self.channel) return;
+    NSLog(@"[BubbleBugRepro] consumePending SCHEDULED");
+    __weak typeof(self) ws = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!ws.pendingReconcile) return; // 期间已被别条路径消费
+        NSLog(@"[BubbleBugRepro] consumePending FIRING");
+        [ws onAppDidBecomeActiveReconcile:nil];
+    });
 }
 
 #pragma mark - WKConversationManagerDelegate

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -1566,36 +1566,49 @@ static const NSInteger kMaxPullupDedupRetry = 3;
 
 
 -(void) startReminderAnimation {
+    // 历史实现把整段包在 [tableView performBatchUpdates:] 里, 但 block 内既没有
+    // insert/delete/move, 也没有 reload (原本那行 reloadRowsAtIndexPaths 已注释掉),
+    // 属于一个"空 batch"。UITableView 对空 batch 会在 block 前后各查一次
+    // numberOfRowsInSection 做一致性校验; 而本方法的入口
+    // (locateMessageCellWithOrderSeqForReminder: → pullAround → loadMessages
+    //  → completion) 是跨 runloop 的异步链, 中间任何一个通知路径 (新消息到达 /
+    // 分页 loadMore) 若已改动 dataProvider 但 tableView 还没被 insertRows 通知,
+    // 空 batch 就会撞上假 delta:
+    //   NSInternalInconsistencyException "invalid number of rows in section 0.
+    //   after update (60) must be equal to before update (30) plus 0 inserted..."
+    // (Bugly #24037 类同款堆栈: onTap → updateReminders → initPosition →
+    //  locateMessageCellWithOrderSeqForReminder → startReminderAnimation →
+    //  _performBatchUpdates)
+    //
+    // 修复: 拿掉 performBatchUpdates 外壳 —— 这段代码本来就没有 batch 语义要维护,
+    // 唯一的实际工作是 0.5s 后拿到 cell 触发 per-cell 的 startReminderAnimation,
+    // 与批量更新完全无关。行为等价, 消除崩溃面。
     NSArray<WKReminder*> *reminders = self.reminders;
-    if(reminders && reminders.count>0) {
-        __weak typeof(self) weakSelf = self;
-        [self.tableView performBatchUpdates:^{
-            NSMutableArray *indexPaths = [NSMutableArray array];
-            for (WKReminder *reminder in reminders) {
-                if(reminder.isLocate && !reminder.done) {
-                    uint32_t orderSeq = [[WKSDK shared].chatManager getOrderSeq:reminder.messageSeq];
-                    NSIndexPath *indexPath = [weakSelf.dataProvider indexPathAtOrderSeq:orderSeq];
-                    if(indexPath) {
-                        [indexPaths addObject:indexPath];
-                    }
-                }
-            }
-            if(indexPaths.count>0) {
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    for (NSIndexPath *indexPath in indexPaths) {
-                        WKMessageBaseCell *cell =  (WKMessageBaseCell*) [weakSelf.tableView cellForRowAtIndexPath:indexPath];
-                        if(cell && [cell isKindOfClass:[WKMessageCell class]]) {
-                            [(WKMessageCell*)cell startReminderAnimation];
-                        }
-                    }
-                   // [weakSelf.tableView reloadRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
-                });
-                
-            }
-        } completion:nil];
-        
+    if(!reminders || reminders.count == 0) {
+        return;
     }
-    
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray array];
+    for (WKReminder *reminder in reminders) {
+        if(reminder.isLocate && !reminder.done) {
+            uint32_t orderSeq = [[WKSDK shared].chatManager getOrderSeq:reminder.messageSeq];
+            NSIndexPath *indexPath = [self.dataProvider indexPathAtOrderSeq:orderSeq];
+            if(indexPath) {
+                [indexPaths addObject:indexPath];
+            }
+        }
+    }
+    if(indexPaths.count == 0) {
+        return;
+    }
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        for (NSIndexPath *indexPath in indexPaths) {
+            WKMessageBaseCell *cell = (WKMessageBaseCell*) [weakSelf.tableView cellForRowAtIndexPath:indexPath];
+            if(cell && [cell isKindOfClass:[WKMessageCell class]]) {
+                [(WKMessageCell*)cell startReminderAnimation];
+            }
+        }
+    });
 }
 
 -(void) scrollToIndex:(NSIndexPath*)indexPath {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -501,11 +501,13 @@ static const BOOL kIncrementalPulldown = NO;
     __weak typeof(self) weakSelf = self;
     WKMessageModel *_dpHeadBefore = [self.dataProvider firstMessage];
     WKMessageModel *_dpTailBefore = [self.dataProvider lastMessage];
+    #if DEBUG
     NSLog(@"[BubbleBugRepro] loadMessages ENTRY animation=%d firstLoad=%d keepPos=%u dpHead=%u dpTail=%u dpCount=date×%lu",
           animation, firstLoad,
           self.keepPosition.orderSeq,
           _dpHeadBefore.orderSeq, _dpTailBefore.orderSeq,
           (unsigned long)self.dataProvider.dates.count);
+    #endif
     if(self.keepPosition) {
         [self enablePullup:YES];
     }else {
@@ -514,10 +516,12 @@ static const BOOL kIncrementalPulldown = NO;
     [self.dataProvider pullFirst:self.keepPosition complete:^(bool hasMore) {
         WKMessageModel *_dpHeadAfter = [weakSelf.dataProvider firstMessage];
         WKMessageModel *_dpTailAfter = [weakSelf.dataProvider lastMessage];
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] loadMessages pullFirst RETURN hasMore=%d dpHead=%u dpTail=%u dpDates=%lu",
               hasMore,
               _dpHeadAfter.orderSeq, _dpTailAfter.orderSeq,
               (unsigned long)weakSelf.dataProvider.dates.count);
+        #endif
         [weakSelf handleLoadMessages:animation firstLoad:firstLoad hasMore:hasMore complete:complete];
     }];
 }
@@ -585,10 +589,12 @@ static const BOOL kIncrementalPulldown = NO;
     {
         WKMessageModel *_dpHead = [self.dataProvider firstMessage];
         WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] _handleLoadAfterPrecache RELOAD firstLoad=%d keepPos=%u dpHead=%u dpTail=%u dpDates=%lu",
               firstLoad, self.keepPosition.orderSeq,
               _dpHead.orderSeq, _dpTail.orderSeq,
               (unsigned long)self.dataProvider.dates.count);
+        #endif
     }
     [self.tableView reloadData];
 
@@ -629,18 +635,24 @@ static const BOOL kIncrementalPulldown = NO;
 -(void) pullBottom {
     WKMessageModel *_dpHead = [self.dataProvider firstMessage];
     WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+    #if DEBUG
     NSLog(@"[BubbleBugRepro] pullBottom ENTRY pullupHasMore=%d positionAtBottom=%d dpHead=%u dpTail=%u lastMsg=%u appState=%ld",
           [self pullupHasMore], self.positionAtBottom,
           _dpHead.orderSeq, _dpTail.orderSeq, self.lastMessage.orderSeq,
           (long)[UIApplication sharedApplication].applicationState);
+    #endif
     if(![self pullupHasMore]) {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] pullBottom PATH=scroll-only (already at bottom in dp)");
+        #endif
         [self pullupFinished];
         [self.tableView setContentOffset:self.tableView.contentOffset animated:NO]; // 立刻停止滚动
         [self scrollToBottom:YES];
         return;
     }
+    #if DEBUG
     NSLog(@"[BubbleBugRepro] pullBottom PATH=reset-load (pullupHasMore=YES)");
+    #endif
     // 标记「下一次 pulldown 强制 reloadData」——见 wasResetLoadPending 属性注释。
     self.wasResetLoadPending = YES;
 
@@ -666,20 +678,35 @@ static const BOOL kIncrementalPulldown = NO;
     WKConversationWrapModel *_convModel = [[WKConversationListVM shared] modelAtChannel:self.channel];
     uint32_t _knownLatestOrderSeq = 0;
     if (_convModel.lastMessage.messageSeq > 0) {
-        _knownLatestOrderSeq = (uint32_t)_convModel.lastMessage.messageSeq * (uint32_t)WKOrderSeqFactor;
+        // 在 uint64 里算, 溢出 uint32 时保持 _knownLatestOrderSeq=0 走 pullFirst:nil
+        // 已有 fallback (line 682-684)。SDK 全线 orderSeq 都是 uint32, 单会话
+        // messageSeq > ~4.29M 是 SDK 级天花板 (WKMessageDB / pullAround:orderSeq: /
+        // WKConversationPosition.orderSeq 全 uint32), 这里只保证不给 keepPosition
+        // 留脏值触发 pullAround 定位到错误的老窗口 (PR #64 review OctoBoooot + Jerry-Xin
+        // 独立命中)。
+        uint64_t _computed = (uint64_t)_convModel.lastMessage.messageSeq * (uint64_t)WKOrderSeqFactor;
+        if (_computed > 0 && _computed <= UINT32_MAX) {
+            _knownLatestOrderSeq = (uint32_t)_computed;
+        }
     }
     __weak typeof(self) weakSelf = self;
     if (_knownLatestOrderSeq > 0) {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] pullBottom SUB=pullAround knownLatestOrderSeq=%u (force server sync)",
               _knownLatestOrderSeq);
+        #endif
         self.keepPosition = [WKConversationPosition orderSeq:_knownLatestOrderSeq offset:0];
         [self loadMessages:true firstLoad:true complete:^{
             weakSelf.keepPosition = nil;
             [weakSelf scrollToBottom:YES];
+            #if DEBUG
             NSLog(@"[BubbleBugRepro] pullBottom SUB=pullAround DONE, scrollToBottom");
+            #endif
         }];
     } else {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] pullBottom SUB=pullFirst:nil FALLBACK (convlist lastMsg not available)");
+        #endif
         self.keepPosition = nil;
         [self loadMessages:true firstLoad:true complete:nil];
     }
@@ -877,9 +904,11 @@ static const BOOL kIncrementalPulldown = NO;
     {
         WKMessageModel *_dpHead = [self.dataProvider firstMessage];
         WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] pulldown ENTRY dpHead=%u dpTail=%u dpDates=%lu positionAtBottom=%d",
               _dpHead.orderSeq, _dpTail.orderSeq,
               (unsigned long)self.dataProvider.dates.count, self.positionAtBottom);
+        #endif
     }
     WK_PERF_LOG(@"[PullDebug] pulldown START, mj_header.state=%ld, isPulldownInProgress=%d", (long)self.tableView.mj_header.state, self.isPulldownInProgress);
 
@@ -975,7 +1004,9 @@ static const BOOL kIncrementalPulldown = NO;
                     BOOL _forceReloadForResetLoad = weakSelf.wasResetLoadPending;
                     weakSelf.wasResetLoadPending = NO;
                     if (_forceReloadForResetLoad) {
+                        #if DEBUG
                         NSLog(@"[BubbleBugRepro] pulldown FORCE reloadData (post-reset-load, 避免 UIKit 增量插入漂移)");
+                        #endif
                     }
 
                     if (kIncrementalPulldown && !_forceReloadForResetLoad && weakSelf && weakSelf.tableView) {
@@ -1060,9 +1091,11 @@ static const BOOL kIncrementalPulldown = NO;
                     {
                         WKMessageModel *_dpHead = [weakSelf.dataProvider firstMessage];
                         WKMessageModel *_dpTail = [weakSelf.dataProvider lastMessage];
+                        #if DEBUG
                         NSLog(@"[BubbleBugRepro] pulldown DONE path=hasInsertions newMsgs=%lu dpHead=%u dpTail=%u dpDates=%lu",
                               (unsigned long)newMsgs.count, _dpHead.orderSeq, _dpTail.orderSeq,
                               (unsigned long)weakSelf.dataProvider.dates.count);
+                        #endif
                     }
                     [weakSelf processPendingRecvMessages];
                     [weakSelf wk_tryConsumePendingReconcile];
@@ -1075,9 +1108,11 @@ static const BOOL kIncrementalPulldown = NO;
             {
                 WKMessageModel *_dpHead = [weakSelf.dataProvider firstMessage];
                 WKMessageModel *_dpTail = [weakSelf.dataProvider lastMessage];
+                #if DEBUG
                 NSLog(@"[BubbleBugRepro] pulldown DONE path=noInsertions dpHead=%u dpTail=%u dpDates=%lu",
                       _dpHead.orderSeq, _dpTail.orderSeq,
                       (unsigned long)weakSelf.dataProvider.dates.count);
+                #endif
             }
             [weakSelf processPendingRecvMessages];
             [weakSelf wk_tryConsumePendingReconcile];
@@ -2204,14 +2239,18 @@ static const NSInteger kMaxPullupDedupRetry = 3;
     WKMessageModel *messageModel = [[WKMessageModel alloc] initWithMessage:message];
     {
         WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] handleRecvMessage ENTRY msgNo=%@ msgOrderSeq=%u dpTail=%u lastMsg=%u pullupHasMore=%d positionAtBottom=%d appState=%ld",
               message.clientMsgNo, messageModel.orderSeq,
               _dpTail.orderSeq, self.lastMessage.orderSeq,
               [self pullupHasMore], self.positionAtBottom,
               (long)[UIApplication sharedApplication].applicationState);
+        #endif
     }
     if([self pullupHasMore]) { // 消息没有完全加载完成
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] handleRecvMessage PATH=pullupHasMore (only updateLastMsgIfNeed) — NEW MSG DROPPED FROM DP");
+        #endif
         [self updateLastMsgIfNeed:messageModel];
         if( [message isSend]) {
             [self  pullBottom];
@@ -2234,8 +2273,10 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         //   相等判断提前 return，永远不会补一次 reloadData。reloadData 是惰性的，回前台下次
         //   layout 会重查 numberOfRows 并重新 willDisplayCell:，自愈（对齐 git-init 的原行为）。
         if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+            #if DEBUG
             NSLog(@"[BubbleBugRepro] handleRecvMessage PATH=background msgOrderSeq=%u dpTail=%u (no gap-fill in bg branch)",
                   messageModel.orderSeq, [self.dataProvider lastMessage].orderSeq);
+            #endif
             // R4 fix: 标记 "回前台 reconcile 时即使 numberOfRows 一致也要强制 reloadData 一次",
             // 治后台 reloadData + scrollToBottom 触发离屏 layout 但 willDisplayCell: 没回调,
             // 回前台 UIKit 误判 "已布局" 不重渲染、cell 内容空白的回归。消费点:
@@ -2511,8 +2552,10 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         if (h > 15.0f) {
             [[WKMessageListView cellHeightCache] setObject:@(h) forKey:heightKey];
         } else {
+            #if DEBUG
             NSLog(@"[BubbleBugRepro] _cachedHeight REJECT pathological h=%.1f msgNo=%@",
                   h, msg.clientMsgNo);
+            #endif
             h = 44.0f;
         }
         return h;
@@ -2550,8 +2593,10 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         if (height > 15.0f) {
             [[WKMessageListView cellHeightCache] setObject:@(height) forKey:heightKey];
         } else {
+            #if DEBUG
             NSLog(@"[BubbleBugRepro] precache REJECT pathological height=%.1f msgNo=%@",
                   height, msg.clientMsgNo);
+            #endif
         }
         CGFloat ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000;
         if (ms > 10) {
@@ -2624,9 +2669,11 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
         // insertSections 增量路径在跨 section + row shift 混合形态下让 UIKit
         // 内部行数簿记漂移。返 0.1 → cell 完全不可见 (症状 B「无气泡框」)。
         // 打日志, 复现时可 grep [BubbleBugRepro] dp/tv drift 直接定位到具体 indexPath。
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] dp/tv drift: heightForRow section=%ld row=%ld returned nil model (dpSections=%lu)",
               (long)indexPath.section, (long)indexPath.row,
               (unsigned long)self.dataProvider.dates.count);
+        #endif
         return 0.1f;
     }
 
@@ -2673,8 +2720,10 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
     if (heightKey && height > 15.0f) {
         [[WKMessageListView cellHeightCache] setObject:@(height) forKey:heightKey];
     } else if (heightKey) {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] heightCache REJECT pathological height=%.1f msgNo=%@ (measure race, will retry)",
               height, messageModel.clientMsgNo);
+        #endif
         // measure race 时返回 44 兜底而不是 0.1, 让本帧至少能看到 cell 存在
         if (height < 15.0f) height = 44.0f;
     }
@@ -3441,11 +3490,13 @@ static const NSInteger kMaxRehydratePages = 35;
     if (!self.channel) {
         return;
     }
+    #if DEBUG
     NSLog(@"[BubbleBugRepro] reconcile ENTRY note=%@ dirty=%d pending=%d pulldown=%d rehydrate=%d pullupMore=%d posAtBottom=%d",
           note.name ?: @"(consume)",
           self.dirtyAfterBackground, self.pendingReconcile,
           self.isPulldownInProgress, self.isRehydrating,
           [self pullupHasMore], self.positionAtBottom);
+    #endif
     // gate 命中早退路径: dirtyAfterBackground 仍为 YES (说明后台真的动过状态、
     // 需要补刷) 时把 pendingReconcile 置位, 等 gate 清掉的回调路径再调
     // wk_tryConsumePendingReconcile 补一次。覆盖三种场景:
@@ -3455,24 +3506,35 @@ static const NSInteger kMaxRehydratePages = 35;
     // 不持锁不抢 tableView, 安全。
     if (self.isPulldownInProgress) {
         if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] reconcile GATE=isPulldownInProgress pendingNow=%d", self.pendingReconcile);
+        #endif
         return;
     }
     if (self.isRehydrating) {
         if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] reconcile GATE=isRehydrating pendingNow=%d", self.pendingReconcile);
+        #endif
         return;
     }
     if ([self pullupHasMore]) {
         if (self.dirtyAfterBackground) self.pendingReconcile = YES;
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] reconcile GATE=pullupHasMore pendingNow=%d", self.pendingReconcile);
+        #endif
         return;
     }
     // 防抖: gate 全部放行后再判, 这样 gate 命中早退不会污染时间戳, 下条通知仍能
     // 补一次。同一回前台动作 (Will*+Did*+SceneWill*+SceneDidActive) 半秒内只跑一次
     // reloadData, 避免连刷抢主线程影响首帧丝滑。
+    //
+    // 例外: relay 路径 (note==nil, wk_tryConsumePendingReconcile 派发) 不受 debounce
+    // 影响 —— 老实现 relay 会撞上 debounce early-return 却不清 pendingReconcile,
+    // 与本方法文档 "接力补刷应当不受 500ms 防抖影响" 相悖 (PR #64 review OctoBoooot 命中)。
     NSTimeInterval _reconcileNow = CFAbsoluteTimeGetCurrent();
-    if (_reconcileNow - self.reconcileLastTs < 0.5) {
+    BOOL _isRelay = (note == nil);
+    if (!_isRelay && _reconcileNow - self.reconcileLastTs < 0.5) {
         return;
     }
     self.reconcileLastTs = _reconcileNow;
@@ -3516,13 +3578,17 @@ static const NSInteger kMaxRehydratePages = 35;
     }
 
     if (needsReload) {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] reconcile RELOAD dirty=%d positionAtBottom=%d", dirty, self.positionAtBottom);
+        #endif
         [self.tableView reloadData];
         if (self.positionAtBottom) {
             [self scrollToBottom:NO];
         }
     } else {
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] reconcile NOOP (no signals)");
+        #endif
     }
     // 真的跑到这里说明 reconcile 主路径已经走过 (或 cheap-path 确认 UI 状态干净),
     // pendingReconcile 就此清掉避免后续 gate-clear 路径无谓再补一次。
@@ -3539,11 +3605,15 @@ static const NSInteger kMaxRehydratePages = 35;
 -(void) wk_tryConsumePendingReconcile {
     if (!self.pendingReconcile) return;
     if (!self.channel) return;
+    #if DEBUG
     NSLog(@"[BubbleBugRepro] consumePending SCHEDULED");
+    #endif
     __weak typeof(self) ws = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!ws.pendingReconcile) return; // 期间已被别条路径消费
+        #if DEBUG
         NSLog(@"[BubbleBugRepro] consumePending FIRING");
+        #endif
         [ws onAppDidBecomeActiveReconcile:nil];
     });
 }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Conversation/WKMessageListView.m
@@ -97,6 +97,19 @@ static const BOOL kIncrementalPulldown = NO;
 // reloadData + scrollToBottom 触发离屏 layout 但 willDisplayCell: 没回调, refresh: 永不跑
 // → 回前台 cell 内容空白" 的回归。设置点: handleRecvMessage 后台分支 + onConversationSyncFinished。
 @property(nonatomic,assign) BOOL dirtyAfterBackground;
+// pullBottom-reset-load 后的下一次 pulldown 强制走 reloadData 路径 (不用增量
+// insertSections + insertRowsAtIndexPaths)。原因:
+//   reset-load 把 dp 从「用户读的历史片段 (dp=[msg 13..72])」整块替换成「最新
+//   一页 (dp=[msg 2334..2363])」, 用户接着上滑 pulldown 拿到的是「几周/几月前
+//   的一大批老历史」, 一定跨多个 date section 且大概率跟老首 section 混合 (既
+//   insert 新 section 又给老首 section 补行)。UIKit 增量 insert 路径在这种
+//   「post-batch section shift + row insert into shifted section」形态下时序敏感
+//   ——已知 Bugly #3054 就是这条路径的漂移。iOS 27 把内部时序改得更严, 更容易
+//   在这条形态上让 dp/tv 行数簿记漂移, heightForRow 拿不到 model 返 0.1 →
+//   cell 完全不显示 (无气泡框、无文字, 症状 B)。
+// reloadData 稍慢但强壮, 反正 reset-load 后第一次 pulldown 用户也预期一个
+// 「跳一下」的过渡感, 视觉损失可忽略。
+@property(nonatomic,assign) BOOL wasResetLoadPending;
 // reconcile 防抖: 同一回前台动作会同时派发 UIApplicationWillEnterForeground /
 // UIApplicationDidBecomeActive / UISceneWillEnterForeground / UISceneDidActivate
 // 多条通知, 全部 hook 到本对账方法。500ms 内重复触发跳过, 避免连刷 reloadData
@@ -569,6 +582,14 @@ static const BOOL kIncrementalPulldown = NO;
              [self.dataProvider addTypingMessageIfNeed:[[WKMessageModel alloc] initWithMessage:typingMessage]];
          }
     }
+    {
+        WKMessageModel *_dpHead = [self.dataProvider firstMessage];
+        WKMessageModel *_dpTail = [self.dataProvider lastMessage];
+        NSLog(@"[BubbleBugRepro] _handleLoadAfterPrecache RELOAD firstLoad=%d keepPos=%u dpHead=%u dpTail=%u dpDates=%lu",
+              firstLoad, self.keepPosition.orderSeq,
+              _dpHead.orderSeq, _dpTail.orderSeq,
+              (unsigned long)self.dataProvider.dates.count);
+    }
     [self.tableView reloadData];
 
     if(!self.keepPosition) {
@@ -619,9 +640,49 @@ static const BOOL kIncrementalPulldown = NO;
         [self scrollToBottom:YES];
         return;
     }
-    NSLog(@"[BubbleBugRepro] pullBottom PATH=reset-load (pullupHasMore=YES) — will pullFirst:nil");
-    self.keepPosition = nil;
-    [self loadMessages:true firstLoad:false complete:nil];
+    NSLog(@"[BubbleBugRepro] pullBottom PATH=reset-load (pullupHasMore=YES)");
+    // 标记「下一次 pulldown 强制 reloadData」——见 wasResetLoadPending 属性注释。
+    self.wasResetLoadPending = YES;
+
+    // 关键根因修复: 不能用 pullFirst:nil (走 SDK pullLastMessages(start=0,end=0))。
+    // SDK 的 pullMessages 在 startOrderSeq==0 时**整个 anchor gap 检查块被 skip**
+    // (line 906 `if(startOrderSeq!=0)`), 且当 local DB 返回的 count == limit 时
+    // 「last-page 兜底 sync」也不触发 (line 995 `if(count<limit)`)。
+    // 后果: fresh install → 用户搜到 3 月 → local DB 只有 3 月 30 条 → 点跳底部走
+    // pullFirst:nil → SDK 静默返回 local newest 30 = 3 月尾部 → dp = 3 月, 但用户
+    // 视觉上误以为在最新 (因为 scrollToBottom 到了当前 dp 底部)。之后 pulldown 拉
+    // 更老 3 月, 完全跳过 4/5/6 月, 症状复现。endOrderSeq bound 是拦 pulldown 拿远古
+    // stale 的下界防线, 但 reset-load 本身返 stale 数据它救不了。
+    //
+    // 修法: 用 pullAround(knownLatestOrderSeq) 替代。pullAround 走 pullMessages
+    // (start=derivedFromLatest, end=0, mode=Up), 命中 line 906+ anchor gap 检查,
+    // 强制 calSync 到 server 拉齐真正 latest → local DB 一定含 latest → dp 一定是
+    // latest 附近, 不再 stale。
+    // 视觉一致性: pullAround 后 keepPosition 让 setContentOffset 停在 latest msg 顶部
+    // 而不是 viewport 底, complete 回调里清 keepPosition + scrollToBottom 修正到底。
+    // convlist lastMessage.messageSeq 是 knownLatest 来源, fresh install 打开 app 后
+    // convManager 会同步 convlist, 一般 > 0。极端 case 拿不到时 fallback 原路径 (无解,
+    // 至少不 worse than before)。
+    WKConversationWrapModel *_convModel = [[WKConversationListVM shared] modelAtChannel:self.channel];
+    uint32_t _knownLatestOrderSeq = 0;
+    if (_convModel.lastMessage.messageSeq > 0) {
+        _knownLatestOrderSeq = (uint32_t)_convModel.lastMessage.messageSeq * (uint32_t)WKOrderSeqFactor;
+    }
+    __weak typeof(self) weakSelf = self;
+    if (_knownLatestOrderSeq > 0) {
+        NSLog(@"[BubbleBugRepro] pullBottom SUB=pullAround knownLatestOrderSeq=%u (force server sync)",
+              _knownLatestOrderSeq);
+        self.keepPosition = [WKConversationPosition orderSeq:_knownLatestOrderSeq offset:0];
+        [self loadMessages:true firstLoad:true complete:^{
+            weakSelf.keepPosition = nil;
+            [weakSelf scrollToBottom:YES];
+            NSLog(@"[BubbleBugRepro] pullBottom SUB=pullAround DONE, scrollToBottom");
+        }];
+    } else {
+        NSLog(@"[BubbleBugRepro] pullBottom SUB=pullFirst:nil FALLBACK (convlist lastMsg not available)");
+        self.keepPosition = nil;
+        [self loadMessages:true firstLoad:true complete:nil];
+    }
 
 }
 
@@ -910,7 +971,14 @@ static const BOOL kIncrementalPulldown = NO;
                     CFAbsoluteTime t_apply = CFAbsoluteTimeGetCurrent();
                     BOOL didIncremental = NO;
 
-                    if (kIncrementalPulldown && weakSelf && weakSelf.tableView) {
+                    // 消费「reset-load 后强制 reloadData」标记, 见属性注释。
+                    BOOL _forceReloadForResetLoad = weakSelf.wasResetLoadPending;
+                    weakSelf.wasResetLoadPending = NO;
+                    if (_forceReloadForResetLoad) {
+                        NSLog(@"[BubbleBugRepro] pulldown FORCE reloadData (post-reset-load, 避免 UIKit 增量插入漂移)");
+                    }
+
+                    if (kIncrementalPulldown && !_forceReloadForResetLoad && weakSelf && weakSelf.tableView) {
                         @try {
                             // 关键修法：跟老 reloadData 路径同源 —— 用 layoutIfNeeded +
                             // rectForRowAtIndexPath:targetCopy 拿 anchor 真实新位置，再调 contentOffset。
@@ -2426,7 +2494,14 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         }
         CGSize size = [cellClass sizeForMessage:msg];
         CGFloat h = MAX(size.height, 0.1f);
-        [[WKMessageListView cellHeightCache] setObject:@(h) forKey:heightKey];
+        // 拒绝写入病态小值 (< 15pt), 见 heightForRowAtIndexPath 里同款注释。
+        if (h > 15.0f) {
+            [[WKMessageListView cellHeightCache] setObject:@(h) forKey:heightKey];
+        } else {
+            NSLog(@"[BubbleBugRepro] _cachedHeight REJECT pathological h=%.1f msgNo=%@",
+                  h, msg.clientMsgNo);
+            h = 44.0f;
+        }
         return h;
     } @catch (NSException *ex) {
         NSLog(@"[CellPerf] _cachedHeightForMessage exception: %@", ex);
@@ -2456,7 +2531,15 @@ static const NSInteger kMaxPullupDedupRetry = 3;
         if ([[WKMessageListView cellHeightCache] objectForKey:heightKey]) return;
         CGSize size = [cellClass sizeForMessage:msg];
         CGFloat height = MAX(size.height, 0.1f);
-        [[WKMessageListView cellHeightCache] setObject:@(height) forKey:heightKey];
+        // 拒绝写入病态小值 (< 15pt), 见 heightForRowAtIndexPath 里同款注释:
+        // measure race 拿到 0 时如果写进 cache 就永久污染, cell 永远 0.1px 空白。
+        // 不写让下次调用重试, 直到拿到正常值。
+        if (height > 15.0f) {
+            [[WKMessageListView cellHeightCache] setObject:@(height) forKey:heightKey];
+        } else {
+            NSLog(@"[BubbleBugRepro] precache REJECT pathological height=%.1f msgNo=%@",
+                  height, msg.clientMsgNo);
+        }
         CGFloat ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000;
         if (ms > 10) {
             NSString *preview = @"";
@@ -2495,9 +2578,44 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
     return _cellHeightCache;
 }
 
+// 统一 heightCache key 计算 + 移除。
+// cellHeightCache 的 key 语义 = clientMsgNo + bubblePos[+editTimestamp], 依赖:
+//   1) 消息本身内容 (clientMsgNo 变则 key 变)
+//   2) bubble 位置 (First/Middle/Last/Alone, 群聊连发气泡合并样式)
+//   3) 编辑时间戳 (contentEdit 后重算)
+// 但实际测出来的高度还依赖多个「异步到达」输入 (sender 昵称 / bot 标识 /
+// 表格 WebView 实测高度 等)。这些数据后到时必须显式 invalidate 对应 msg 的
+// heightCache, 否则 cache 命中的是「旧数据下算的高度」→ 气泡框高度不匹配
+// 新内容 (Bug 1) / bot AI 标识 frame 计算基于旧宽度 (Bug 3) 等。
+// 用法: 数据变化路径 (channelInfoUpdate / WebView didFinish / member 更新 等) 里
+// 调用本方法 + reload/refresh 让 UITableView 重新问高度。
+- (void)wk_invalidateHeightCacheForMessage:(WKMessageModel*)msg {
+    if (!msg || msg.clientMsgNo.length == 0) return;
+    Class cellClass = [self getMessageCellClass:msg];
+    NSInteger bubblePos = 0;
+    if ([cellClass respondsToSelector:@selector(bubblePosition:)]) {
+        bubblePos = [cellClass bubblePosition:msg];
+    }
+    NSString *heightKey = [NSString stringWithFormat:@"%@-bp%ld", msg.clientMsgNo, (long)bubblePos];
+    if (msg.remoteExtra.contentEdit) {
+        heightKey = [NSString stringWithFormat:@"%@-e%lu", heightKey, (unsigned long)msg.remoteExtra.editedAt];
+    }
+    [[WKMessageListView cellHeightCache] removeObjectForKey:heightKey];
+}
+
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath{
     WKMessageModel *messageModel = [self.dataProvider messageAtIndexPath:indexPath];
-    if (!messageModel) return 0.1f;
+    if (!messageModel) {
+        // dp/tv 漂移检测: UITableView 询问的 indexPath 在 dp 里查不到 model → 说明
+        // numberOfRowsInSection 计算和实际 dp 内容不一致, 大概率是 insertRows /
+        // insertSections 增量路径在跨 section + row shift 混合形态下让 UIKit
+        // 内部行数簿记漂移。返 0.1 → cell 完全不可见 (症状 B「无气泡框」)。
+        // 打日志, 复现时可 grep [BubbleBugRepro] dp/tv drift 直接定位到具体 indexPath。
+        NSLog(@"[BubbleBugRepro] dp/tv drift: heightForRow section=%ld row=%ld returned nil model (dpSections=%lu)",
+              (long)indexPath.section, (long)indexPath.row,
+              (unsigned long)self.dataProvider.dates.count);
+        return 0.1f;
+    }
 
     // 流式消息不缓存高度（内容还在变化）
     BOOL isStreaming = messageModel.streamOn && messageModel.streamFlag != WKStreamFlagEnd;
@@ -2528,8 +2646,24 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
         NSLog(@"[HeightCache] heightForRow exception at %@: %@", indexPath, exception);
     }
 
-    if (heightKey) {
+    // heightCache 只写「合理值」, 拒绝写入病态小值。原因:
+    //   iOS 27 主线程 UITextView 首帧 measure 存在时序 race 会返 0
+    //   (TK2→TK1 fallback 尚未完成时 sizeThatFits 拿不到 glyph)。
+    //   老实现 `MAX(cellSize.height, 0.1f)` 拿到 0 会写 0.1 进 cache, 后续
+    //   heightForRow 全部命中 0.1 → cell 永久 0.1px 高 → 全空白, 且**没有自愈**
+    //   (cache 命中就 return 不再走 measure)。fresh install (cache 全空,
+    //   一定走 measure) 才会大规模复现。
+    //   阈值 15pt: 空文本气泡最小也 >20pt (avatar+padding), 15pt 以下一定不合理。
+    //   不合理时不写 cache, 让下一次 heightForRow 重试 measure, 直到拿到正常值。
+    // 副作用: 病态窗口内 UITableView 拿到本次 return 的 44/0.1 短暂错位一帧,
+    // 下一次 layout 立刻自愈。远好于永久空白。
+    if (heightKey && height > 15.0f) {
         [[WKMessageListView cellHeightCache] setObject:@(height) forKey:heightKey];
+    } else if (heightKey) {
+        NSLog(@"[BubbleBugRepro] heightCache REJECT pathological height=%.1f msgNo=%@ (measure race, will retry)",
+              height, messageModel.clientMsgNo);
+        // measure race 时返回 44 兜底而不是 0.1, 让本帧至少能看到 cell 存在
+        if (height < 15.0f) height = 44.0f;
     }
 
     if (WKCellPerfLog) {
@@ -2972,19 +3106,52 @@ static NSCache<NSString*, NSNumber*> *_cellHeightCache;
         if(channelInfo.channel.channelType != WK_PERSON) {
             return;
         }
-       NSArray<UITableViewCell*> *visibleCells =  self.tableView.visibleCells;
-        if(visibleCells && visibleCells.count>0) {
-            for (UITableViewCell *tableCell in visibleCells) {
-                if([tableCell isKindOfClass:WKMessageCell.class]) {
-                    WKMessageCell *messageCell = (WKMessageCell*)tableCell;
-                    WKMessageModel *messageModel = messageCell.messageModel;
-                    if(messageModel &&  [messageModel.fromUid isEqual:channelInfo.channel.channelId]) {
-                        messageModel.from = nil;
-                        [messageCell refresh:messageModel];
+        // 关键: sender/bot info 异步到达后, 必须做三件事:
+        //   1) 全 dp iterate: 找出所有 fromUid 匹配的 msg (不止 visible cells,
+        //      非 visible 也要处理, 否则用户滚过去时看到 stale 状态)
+        //   2) 每条匹配 msg: 清 model.from (让 refresh 重读缓存) + 失效 heightCache
+        //      (heightCache 的高度是基于旧的空 name 算的, 保留会让 tableView 复用
+        //      错误高度 → Bug 1「气泡高度错」; refresh 后 layoutSubviews 会用新
+        //      name 宽度重算 nameLbl / botBadge frame → 修 Bug 3「AI 标识错位」)
+        //   3) 对 visible cells 主动 refresh + begin/endUpdates 让 UITableView
+        //      重新问高度 (heightCache 已被失效, 这次问会走 measure 拿新值)
+        // 非 visible 匹配 msg 不主动 reload, 依靠 heightCache 失效, 下次进入 visible
+        // 走 heightForRowAtIndexPath → measure MISS → 拿新高度, 自然收敛。
+        NSString *targetFromUid = channelInfo.channel.channelId;
+        NSMutableSet<NSString*> *affectedClientMsgNos = [NSMutableSet set];
+        for (NSInteger section = 0; section < [self.dataProvider dateCount]; section++) {
+            NSArray<WKMessageModel*> *msgs = [self.dataProvider messagesAtSection:section];
+            for (WKMessageModel *msg in msgs) {
+                if (msg.fromUid.length > 0 && [msg.fromUid isEqualToString:targetFromUid]) {
+                    msg.from = nil; // 让下次 refresh 重读 sender 缓存
+                    [self wk_invalidateHeightCacheForMessage:msg];
+                    if (msg.clientMsgNo.length > 0) {
+                        [affectedClientMsgNos addObject:msg.clientMsgNo];
                     }
-                    
                 }
             }
+        }
+        if (affectedClientMsgNos.count == 0) return;
+
+        NSArray<UITableViewCell*> *visibleCells = self.tableView.visibleCells;
+        BOOL anyVisibleAffected = NO;
+        for (UITableViewCell *tableCell in visibleCells) {
+            if (![tableCell isKindOfClass:WKMessageCell.class]) continue;
+            WKMessageCell *messageCell = (WKMessageCell*)tableCell;
+            WKMessageModel *messageModel = messageCell.messageModel;
+            if (messageModel && [affectedClientMsgNos containsObject:messageModel.clientMsgNo]) {
+                [messageCell refresh:messageModel];
+                anyVisibleAffected = YES;
+            }
+        }
+        // begin/endUpdates 空块强制 UITableView 重新 query 可见行高度; heightCache
+        // 已被上面失效, 这次会走 measure 拿到基于新 sender info 的正确高度, 气泡
+        // 框自动调整到匹配内容。performWithoutAnimation 避免视觉跳动。
+        if (anyVisibleAffected) {
+            [UIView performWithoutAnimation:^{
+                [self.tableView beginUpdates];
+                [self.tableView endUpdates];
+            }];
         }
 //         [self.tableView reloadData]; // TODO: 不要用reloadData 会导致长按菜单错位
     }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/Category/WKCategoryReorderVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/Category/WKCategoryReorderVC.m
@@ -167,6 +167,16 @@
         }]];
     }
     [alert addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    // iPad 上 actionSheet 走 popover, 必须有非 nil 的 sourceView + sourceRect,
+    // 否则 present 时抛 NSGenericException。锚到被点击的 cell; 拿不到 cell (罕见)
+    // 时兜底 self.view 中心。
+    if (alert.popoverPresentationController) {
+        UIView *anchor = [_tableView cellForRowAtIndexPath:indexPath] ?: self.view;
+        alert.popoverPresentationController.sourceView = anchor;
+        alert.popoverPresentationController.sourceRect = CGRectMake(anchor.bounds.size.width / 2,
+                                                                    anchor.bounds.size.height / 2, 0, 0);
+        alert.popoverPresentationController.permittedArrowDirections = 0;
+    }
     [self presentViewController:alert animated:YES completion:nil];
 }
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListCell.m
@@ -795,9 +795,20 @@ static BOOL WKCellIsMuted(WKConversationWrapModel *model) {
     // 所有 tab 统一走右下角 badgeView。最近 tab 之前用头像右上角徽章已下线 —— 红点挪到
     // 与最后一条消息预览同一水平线，颜色与关注 tab 统一为粉底红字。
     self.badgeView.hidden = YES;
-    if(model.unreadCount>0) {
+    // 最近 tab 里父群行的预览时间 / 内容来自 lastChildConversation（子区最新一条），
+    // 但 wrap.unreadCount 只读主群自身 c.unreadCount，子区消息不 tick 主群 unread。
+    // 这会让长时间后台后收到子区消息时出现「时间对但红点不亮」的现象（用户 repro:
+    // 锁屏 app 挂后台数小时 → 子区推送到达 → 会话列表最新时间刷新了但 badge 保持旧值,
+    // 杀 app 冷启 loadConversationList 从 DB 全量重建后 badge 恢复）。
+    // 最近 tab 走 recentTabActivityUnreadCount：主群 + 最新子区。关注 tab（父群
+    // group-summary）保持 unreadCount：那边子区在 threadToggle 上有独立 indicator,
+    // 双算会重复计数。
+    NSInteger displayUnread = self.recentTabContext
+        ? model.recentTabActivityUnreadCount
+        : model.unreadCount;
+    if(displayUnread > 0) {
         self.badgeView.hidden = NO;
-        self.badgeView.badgeValue = self.model.unreadCount > 99 ? @"99+" : [NSString stringWithFormat:@"%ld",(long)self.model.unreadCount];
+        self.badgeView.badgeValue = displayUnread > 99 ? @"99+" : [NSString stringWithFormat:@"%ld",(long)displayUnread];
         self.badgeView.lim_left = self.lim_width - 15.0f - self.badgeView.lim_width; // 这里强行执行下lim_left 因为杀掉app收离线，从无红点到有红点会向左漂移，因为layoutSubviews后执行
     }
 }
@@ -810,7 +821,10 @@ static BOOL WKCellIsMuted(WKConversationWrapModel *model) {
     self.avatarUnreadBadge.hidden = YES;
 
     if(muted) { // 免打扰
-        if(model.unreadCount<=0) {
+        // 与 refreshUnread 同源：最近 tab 走 recentTabActivityUnreadCount,
+        // 否则会出现「静音群收到子区消息 → badge 该亮但 muteIcon 挡在原位」的错位。
+        NSInteger effUnread = self.recentTabContext ? model.recentTabActivityUnreadCount : model.unreadCount;
+        if(effUnread <= 0) {
             self.muteIcon.hidden = NO;
         }else {
             self.muteIcon.hidden = YES;
@@ -1289,7 +1303,11 @@ static BOOL WKCellIsMuted(WKConversationWrapModel *model) {
         self.lastContentLbl.lim_left = self.titleLbl.lim_left - titleIconReserve;
         self.lastContentLbl.lim_width = self.lim_width - self.lastContentLbl.lim_left - 10.0f;
 
-        if(self.model.unreadCount>0 || self.model.mute) {
+        // 与 refreshUnread / refreshSetting 同源：最近 tab 下右下角是否被 badge/mute
+        // 占位需要按 recentTabActivityUnreadCount 判定，否则子区新消息触发 badge 显示
+        // 时 preview 没让位会与 badge 重叠。
+        NSInteger effUnread = self.recentTabContext ? self.model.recentTabActivityUnreadCount : self.model.unreadCount;
+        if(effUnread > 0 || self.model.mute) {
             // 右下角槽位：未读 badge / 静音铃铛会占用 ~40pt，preview 文字让位避免重叠。
             // 最近 tab 现在与关注 tab 统一走右下角 badgeView，红点出现时同样需要让位。
             self.lastContentLbl.lim_width -= 40.0f;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchAPI.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchAPI.h
@@ -1,0 +1,43 @@
+//
+//  WKChannelHistorySearchAPI.h
+//  WuKongBase
+//
+//  统一调用 messages/_search_all / _search / _search_media / _search_files。
+//  与 web 端 packages/dmworkbase/src/Components/ChannelSearch/apiAdapter.ts 同口径。
+//
+
+#import <Foundation/Foundation.h>
+#import <PromiseKit/PromiseKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+@class WKChannel;
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSInteger const WKChannelHistorySearchDefaultPageSize;
+
+@interface WKChannelHistorySearchAPI : NSObject
+
+/// 单次搜索请求。返回 promise resolve(WKChannelHistorySearchPage*)。
+/// keyword 调用方应已经过 truncate；filter 可为 nil。
++ (AnyPromise *)searchWithTab:(WKChannelHistorySearchTab)tab
+                      channel:(WKChannel *)channel
+                      keyword:(nullable NSString *)keyword
+                       filter:(nullable WKChannelHistorySearchFilter *)filter
+                       cursor:(nullable NSString *)cursor
+                     pageSize:(NSInteger)pageSize;
+
+/// 是否应该发起请求（与 web shouldRunSearch 同口径）：
+///   - 全部 / 聊天记录 tab：keyword 非空，或有发送人/日期筛选
+///   - 图片视频 / 文件 tab：始终允许
++ (BOOL)shouldRunSearchForTab:(WKChannelHistorySearchTab)tab
+                      keyword:(nullable NSString *)keyword
+                    hasFilter:(BOOL)hasEffectiveFilter;
+
+/// 当前 tab 是否会把 keyword 传给服务端（false 表示发送时会丢弃 keyword）。
+/// 用于 UI 上对图片视频 tab 显示「图片和视频暂不支持按关键词搜索，可按发送人或日期查找」。
++ (BOOL)keywordSupportedForTab:(WKChannelHistorySearchTab)tab;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchAPI.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchAPI.m
@@ -1,0 +1,76 @@
+//
+//  WKChannelHistorySearchAPI.m
+//
+
+#import "WKChannelHistorySearchAPI.h"
+#import "WKChannelHistorySearchKeywordUtil.h"
+#import "WKAPIClient.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+
+NSInteger const WKChannelHistorySearchDefaultPageSize = 20;
+
+@implementation WKChannelHistorySearchAPI
+
++ (NSString *)endpointForTab:(WKChannelHistorySearchTab)tab {
+    switch (tab) {
+        case WKChannelHistorySearchTabAll:     return @"messages/_search_all";
+        case WKChannelHistorySearchTabMessage: return @"messages/_search";
+        case WKChannelHistorySearchTabMedia:   return @"messages/_search_media";
+        case WKChannelHistorySearchTabFile:    return @"messages/_search_files";
+    }
+}
+
++ (BOOL)keywordSupportedForTab:(WKChannelHistorySearchTab)tab {
+    // 与 web 一致：media tab 完全不带 keyword；file tab 仅当 keyword 非空时带。
+    // "keywordSupported" 这里语义是「该 tab 是否把 keyword 作为搜索条件」。
+    // 媒体 tab 视为不支持关键词检索（UI 据此提示）。
+    return tab != WKChannelHistorySearchTabMedia;
+}
+
++ (BOOL)shouldRunSearchForTab:(WKChannelHistorySearchTab)tab
+                      keyword:(NSString *)keyword
+                    hasFilter:(BOOL)hasEffectiveFilter {
+    if (tab == WKChannelHistorySearchTabMedia || tab == WKChannelHistorySearchTabFile) return YES;
+    NSString *trimmed = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length > 0) return YES;
+    return hasEffectiveFilter;
+}
+
++ (NSString *)sortStringFromEnum:(WKChannelHistorySearchSort)sort {
+    return sort == WKChannelHistorySearchSortTimeAsc ? @"time_asc" : @"time_desc";
+}
+
++ (AnyPromise *)searchWithTab:(WKChannelHistorySearchTab)tab
+                      channel:(WKChannel *)channel
+                      keyword:(NSString *)keyword
+                       filter:(WKChannelHistorySearchFilter *)filter
+                       cursor:(NSString *)cursor
+                     pageSize:(NSInteger)pageSize {
+    NSString *endpoint = [self endpointForTab:tab];
+    NSMutableDictionary *body = [NSMutableDictionary dictionary];
+    body[@"channel_id"] = channel.channelId ?: @"";
+    body[@"channel_type"] = @(channel.channelType);
+    NSDictionary *filterDict = filter ? [filter toApiDict] : @{};
+    body[@"filters"] = filterDict;
+    body[@"sort"] = [self sortStringFromEnum:filter ? filter.sort : WKChannelHistorySearchSortTimeDesc];
+    body[@"page_size"] = @(pageSize > 0 ? pageSize : WKChannelHistorySearchDefaultPageSize);
+    body[@"cursor"] = cursor.length > 0 ? cursor : @"";
+
+    // keyword 规则：与 web apiAdapter.toRequestBody 一致
+    NSString *trimmed = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] ?: @"";
+    NSString *finalKw = [WKChannelHistorySearchKeywordUtil truncateToDefault:trimmed didTruncate:NULL];
+    if (tab == WKChannelHistorySearchTabAll || tab == WKChannelHistorySearchTabMessage) {
+        body[@"keyword"] = finalKw;
+    } else if (tab == WKChannelHistorySearchTabFile && finalKw.length > 0) {
+        body[@"keyword"] = finalKw;
+    }
+    // media tab 不传 keyword
+
+    NSString *cid = channel.channelId;
+    NSInteger ct = channel.channelType;
+    return [WKAPIClient.sharedClient POST:endpoint parameters:body].then(^id(id result) {
+        return [WKChannelHistorySearchPage pageFromResponse:result tab:tab channelId:cid channelType:ct];
+    });
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchModels.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchModels.h
@@ -1,0 +1,169 @@
+//
+//  WKChannelHistorySearchModels.h
+//  WuKongBase
+//
+//  频道内"查找聊天内容" — 数据模型与枚举。与 web 端
+//  packages/dmworkbase/src/Components/ChannelSearch/types.ts / apiAdapter.ts 同口径。
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// 顶部 tab — 与 web 端 ChannelSearchTab 一一对应。
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchTab) {
+    WKChannelHistorySearchTabAll = 0,     // 全部           messages/_search_all
+    WKChannelHistorySearchTabMessage,     // 聊天记录       messages/_search
+    WKChannelHistorySearchTabMedia,       // 图片视频       messages/_search_media
+    WKChannelHistorySearchTabFile,        // 文件           messages/_search_files
+};
+
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchItemKind) {
+    WKChannelHistorySearchItemKindMessage = 0,
+    WKChannelHistorySearchItemKindMedia,
+    WKChannelHistorySearchItemKindFile,
+};
+
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchMessageKind) {
+    WKChannelHistorySearchMessageKindText = 0,
+    WKChannelHistorySearchMessageKindForward,
+    WKChannelHistorySearchMessageKindQuote,
+    WKChannelHistorySearchMessageKindImage,
+    WKChannelHistorySearchMessageKindVideo,
+    WKChannelHistorySearchMessageKindRichText,
+};
+
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchMediaKind) {
+    WKChannelHistorySearchMediaKindImage = 0,
+    WKChannelHistorySearchMediaKindVideo,
+};
+
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchSort) {
+    WKChannelHistorySearchSortTimeDesc = 0,  // 时间倒序（默认）
+    WKChannelHistorySearchSortTimeAsc,       // 时间正序
+};
+
+#pragma mark - Filter
+
+/// 筛选条件（草稿 / 已应用通用）。
+/// 与 web ChannelSearchFilters 同口径: senderUids / startAt / endAt / sort。
+@interface WKChannelHistorySearchFilter : NSObject <NSCopying>
+
+/// 选中的发送人 uid 列表（最多 50，符合服务端约束）。
+@property (nonatomic, copy, nullable) NSArray<NSString *> *senderUids;
+/// 起止日期（精度到天）。为空表示不限制。
+@property (nonatomic, strong, nullable) NSDate *startDate;
+@property (nonatomic, strong, nullable) NSDate *endDate;
+/// 排序方式，默认时间倒序。
+@property (nonatomic, assign) WKChannelHistorySearchSort sort;
+
+/// 是否有任何生效筛选条件（任一字段非空且 sort != desc 时也算）。
+- (BOOL)hasAnyFilter;
+/// 仅看是否有发送人/日期的"硬"筛选（用于 shouldRunSearch 判定）。
+- (BOOL)hasEffectiveFilters;
+
+/// 序列化为 API 请求体 `filters` 字段。日期会被格式化为 `yyyy-MM-dd`。
+- (NSDictionary *)toApiDict;
+
+@end
+
+#pragma mark - Item
+
+/// 单条命中项。覆盖三种 kind：message / media / file。
+/// "全部" tab 服务端返回 combined hit，其中 result_type 决定 kind，
+/// 真正字段在 message / media / file 子字典里 —— combinedItemFromDict: 已处理。
+@interface WKChannelHistorySearchItem : NSObject
+
+@property (nonatomic, assign) WKChannelHistorySearchItemKind kind;
+
+#pragma mark 公共字段
+@property (nonatomic, copy, nullable) NSString *channelId;
+@property (nonatomic, assign) NSInteger channelType;
+@property (nonatomic, copy, nullable) NSString *messageId;
+@property (nonatomic, assign) NSInteger messageSeq;
+@property (nonatomic, copy, nullable) NSString *senderId;
+@property (nonatomic, copy, nullable) NSString *senderName;
+@property (nonatomic, copy, nullable) NSString *senderAvatarUrl;
+/// 消息时间（秒）。若服务端 sent_at 为 ISO 字符串或毫秒，解析时统一规整为秒。
+@property (nonatomic, assign) NSTimeInterval timestamp;
+/// "全部" tab 中服务端排序键 sorted_at，前端不解析，仅透传供调试。
+@property (nonatomic, copy, nullable) NSString *sortedAtRaw;
+
+#pragma mark 消息字段
+@property (nonatomic, assign) WKChannelHistorySearchMessageKind messageKind;
+/// 摘要文本，可能包含 `<mark>关键词</mark>` 高亮标记。
+@property (nonatomic, copy, nullable) NSString *snippet;
+/// 命中理由（用于合并转发/富文本），优先于 snippet 展示一行说明。
+@property (nonatomic, copy, nullable) NSString *matchReason;
+/// 合并转发外层：标题
+@property (nonatomic, copy, nullable) NSString *forwardTitle;
+/// 合并转发外层：子条总数
+@property (nonatomic, assign) NSInteger forwardChildCount;
+/// 合并转发内层预览（最多展示前 N 条）
+@property (nonatomic, copy, nullable) NSArray<NSDictionary *> *innerMessages;
+/// 引用消息字段
+@property (nonatomic, copy, nullable) NSString *quotedSenderName;
+@property (nonatomic, copy, nullable) NSString *quotedText;
+/// 富文本纯文本兜底 (rich_text.plain) —— 服务端对富文本/Markdown 消息, snippet 可能为空,
+/// 真正带关键词的正文在 rich_text.plain 里 (与 web hit.snippet || hit.rich_text.plain 同口径)。
+@property (nonatomic, copy, nullable) NSString *richTextPlain;
+
+#pragma mark 媒体字段
+@property (nonatomic, assign) WKChannelHistorySearchMediaKind mediaKind;
+@property (nonatomic, copy, nullable) NSString *thumbUrl;
+@property (nonatomic, copy, nullable) NSString *originalUrl; // url / image_url / video_url / media_url 中任一可用
+@property (nonatomic, copy, nullable) NSString *previewUrl;
+@property (nonatomic, assign) NSInteger width;
+@property (nonatomic, assign) NSInteger height;
+@property (nonatomic, assign) NSInteger durationMs;
+@property (nonatomic, copy, nullable) NSString *monthBucket; // e.g. "2026-06"
+
+#pragma mark 文件字段
+@property (nonatomic, copy, nullable) NSString *fileName;
+@property (nonatomic, assign) long long fileSizeBytes;
+@property (nonatomic, copy, nullable) NSString *fileExt;
+@property (nonatomic, copy, nullable) NSString *fileDownloadUrl;
+@property (nonatomic, copy, nullable) NSString *filePreviewUrl;
+
+#pragma mark 工厂
+
+/// 解析 messages/_search 返回的 hit dict。
++ (instancetype)messageItemFromDict:(NSDictionary *)dict
+                       fallbackChannelId:(nullable NSString *)fallbackChannelId
+                     fallbackChannelType:(NSInteger)fallbackChannelType;
+/// 解析 messages/_search_media 返回的 hit dict。
++ (instancetype)mediaItemFromDict:(NSDictionary *)dict
+                     fallbackChannelId:(nullable NSString *)fallbackChannelId
+                   fallbackChannelType:(NSInteger)fallbackChannelType;
+/// 解析 messages/_search_files 返回的 hit dict。
++ (instancetype)fileItemFromDict:(NSDictionary *)dict
+                    fallbackChannelId:(nullable NSString *)fallbackChannelId
+                  fallbackChannelType:(NSInteger)fallbackChannelType;
+/// 解析 messages/_search_all 返回的 combined hit。dict 形如
+/// `{ result_type: "message" | "file" | "media", sorted_at, message?:{...}, file?:{...}, media?:{...} }`。
+/// 返回 nil 表示无法识别。
++ (nullable instancetype)combinedItemFromDict:(NSDictionary *)dict
+                                  fallbackChannelId:(nullable NSString *)fallbackChannelId
+                                fallbackChannelType:(NSInteger)fallbackChannelType;
+
+/// 是否可"定位到聊天"。messageSeq > 0 即可。
+- (BOOL)canLocate;
+
+@end
+
+#pragma mark - Page
+
+/// 一页搜索结果（envelope: `{data: [...], pagination: {has_more, next_cursor}}` 兼容裸数组）。
+@interface WKChannelHistorySearchPage : NSObject
+@property (nonatomic, copy) NSArray<WKChannelHistorySearchItem *> *items;
+@property (nonatomic, assign) BOOL hasMore;
+@property (nonatomic, copy, nullable) NSString *nextCursor;
+
+/// 解析 API 响应体。tab 决定如何映射每个 hit。
++ (instancetype)pageFromResponse:(id)response
+                              tab:(WKChannelHistorySearchTab)tab
+                     channelId:(nullable NSString *)channelId
+                   channelType:(NSInteger)channelType;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchModels.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/API/WKChannelHistorySearchModels.m
@@ -1,0 +1,378 @@
+//
+//  WKChannelHistorySearchModels.m
+//  WuKongBase
+//
+
+#import "WKChannelHistorySearchModels.h"
+
+#pragma mark - Helpers
+
+static NSString * _Nullable WKCHS_String(id _Nullable v) {
+    if ([v isKindOfClass:[NSString class]]) return (NSString *)v;
+    if ([v isKindOfClass:[NSNumber class]]) return [(NSNumber *)v stringValue];
+    return nil;
+}
+
+static NSInteger WKCHS_Int(id _Nullable v) {
+    if ([v isKindOfClass:[NSNumber class]]) return [(NSNumber *)v integerValue];
+    if ([v isKindOfClass:[NSString class]]) return [(NSString *)v integerValue];
+    return 0;
+}
+
+static long long WKCHS_Int64(id _Nullable v) {
+    if ([v isKindOfClass:[NSNumber class]]) return [(NSNumber *)v longLongValue];
+    if ([v isKindOfClass:[NSString class]]) return [(NSString *)v longLongValue];
+    return 0;
+}
+
+static NSArray<NSDictionary *> * _Nullable WKCHS_Array(id _Nullable v) {
+    if ([v isKindOfClass:[NSArray class]]) return (NSArray *)v;
+    return nil;
+}
+
+static NSDictionary * _Nullable WKCHS_Dict(id _Nullable v) {
+    if ([v isKindOfClass:[NSDictionary class]]) return (NSDictionary *)v;
+    return nil;
+}
+
+/// 把 sent_at 规整成秒级 NSTimeInterval。兼容三种格式：
+///   - 整数 / 字符串数字：>= 1e12 视为毫秒，否则秒。
+///   - ISO8601 字符串：用静态 formatter 解析。
+static NSTimeInterval WKCHS_ParseTimestamp(id _Nullable v) {
+    if (!v || v == [NSNull null]) return 0;
+    if ([v isKindOfClass:[NSNumber class]]) {
+        double n = [(NSNumber *)v doubleValue];
+        return n >= 1e12 ? n / 1000.0 : n;
+    }
+    if ([v isKindOfClass:[NSString class]]) {
+        NSString *s = (NSString *)v;
+        if (s.length == 0) return 0;
+        // 纯数字串
+        BOOL allDigits = YES;
+        for (NSUInteger i = 0; i < s.length; i++) {
+            unichar c = [s characterAtIndex:i];
+            if (!((c >= '0' && c <= '9') || c == '.')) { allDigits = NO; break; }
+        }
+        if (allDigits) {
+            double n = [s doubleValue];
+            return n >= 1e12 ? n / 1000.0 : n;
+        }
+        // ISO8601
+        static NSISO8601DateFormatter *fmt = nil;
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            fmt = [NSISO8601DateFormatter new];
+            fmt.formatOptions = NSISO8601DateFormatWithInternetDateTime | NSISO8601DateFormatWithFractionalSeconds;
+        });
+        NSDate *d = [fmt dateFromString:s];
+        if (!d) {
+            // 兼容不带毫秒
+            NSISO8601DateFormatter *fmt2 = [NSISO8601DateFormatter new];
+            fmt2.formatOptions = NSISO8601DateFormatWithInternetDateTime;
+            d = [fmt2 dateFromString:s];
+        }
+        return d ? d.timeIntervalSince1970 : 0;
+    }
+    return 0;
+}
+
+/// 把 message_kind 字符串映射为枚举。
+static WKChannelHistorySearchMessageKind WKCHS_ParseMessageKind(NSString * _Nullable s) {
+    if ([s isEqualToString:@"forward"]) return WKChannelHistorySearchMessageKindForward;
+    if ([s isEqualToString:@"quote"]) return WKChannelHistorySearchMessageKindQuote;
+    if ([s isEqualToString:@"image"]) return WKChannelHistorySearchMessageKindImage;
+    if ([s isEqualToString:@"video"]) return WKChannelHistorySearchMessageKindVideo;
+    if ([s isEqualToString:@"rich_text"]) return WKChannelHistorySearchMessageKindRichText;
+    return WKChannelHistorySearchMessageKindText;
+}
+
+static WKChannelHistorySearchMediaKind WKCHS_ParseMediaKind(NSString * _Nullable s) {
+    if ([s isEqualToString:@"video"]) return WKChannelHistorySearchMediaKindVideo;
+    return WKChannelHistorySearchMediaKindImage;
+}
+
+#pragma mark - Filter
+
+@implementation WKChannelHistorySearchFilter
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _sort = WKChannelHistorySearchSortTimeDesc;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    WKChannelHistorySearchFilter *c = [[[self class] allocWithZone:zone] init];
+    c.senderUids = [self.senderUids copy];
+    c.startDate = self.startDate;
+    c.endDate = self.endDate;
+    c.sort = self.sort;
+    return c;
+}
+
+- (BOOL)hasEffectiveFilters {
+    if (self.senderUids.count > 0) return YES;
+    if (self.startDate) return YES;
+    if (self.endDate) return YES;
+    return NO;
+}
+
+- (BOOL)hasAnyFilter {
+    if ([self hasEffectiveFilters]) return YES;
+    return self.sort != WKChannelHistorySearchSortTimeDesc;
+}
+
+- (NSDictionary *)toApiDict {
+    NSMutableDictionary *d = [NSMutableDictionary dictionary];
+    if (self.senderUids.count > 0) {
+        NSUInteger n = MIN(self.senderUids.count, (NSUInteger)50);
+        d[@"sender_ids"] = [self.senderUids subarrayWithRange:NSMakeRange(0, n)];
+    }
+    static NSDateFormatter *fmt = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        fmt = [NSDateFormatter new];
+        fmt.dateFormat = @"yyyy-MM-dd";
+        fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        fmt.timeZone = [NSTimeZone localTimeZone];
+    });
+    if (self.startDate) d[@"sent_at_from"] = [fmt stringFromDate:self.startDate];
+    if (self.endDate) d[@"sent_at_to"] = [fmt stringFromDate:self.endDate];
+    return d;
+}
+
+@end
+
+#pragma mark - Item
+
+@implementation WKChannelHistorySearchItem
+
+- (BOOL)canLocate {
+    return self.messageSeq > 0;
+}
+
+#pragma mark 公共字段填充
+
+- (void)applyCommonFromDict:(NSDictionary *)dict
+              fallbackChannelId:(nullable NSString *)fallbackChannelId
+            fallbackChannelType:(NSInteger)fallbackChannelType {
+    self.messageId = WKCHS_String(dict[@"message_id"]);
+    self.messageSeq = WKCHS_Int(dict[@"message_seq"]);
+    self.senderId = WKCHS_String(dict[@"sender_id"]);
+    self.senderName = WKCHS_String(dict[@"sender_name"]);
+    self.senderAvatarUrl = WKCHS_String(dict[@"sender_avatar_url"]);
+    self.timestamp = WKCHS_ParseTimestamp(dict[@"sent_at"]);
+    NSString *cid = WKCHS_String(dict[@"channel_id"]);
+    self.channelId = cid.length > 0 ? cid : fallbackChannelId;
+    NSInteger ct = WKCHS_Int(dict[@"channel_type"]);
+    self.channelType = ct > 0 ? ct : fallbackChannelType;
+}
+
++ (instancetype)messageItemFromDict:(NSDictionary *)dict
+                       fallbackChannelId:(nullable NSString *)fallbackChannelId
+                     fallbackChannelType:(NSInteger)fallbackChannelType {
+    WKChannelHistorySearchItem *it = [WKChannelHistorySearchItem new];
+    it.kind = WKChannelHistorySearchItemKindMessage;
+    [it applyCommonFromDict:dict
+              fallbackChannelId:fallbackChannelId
+            fallbackChannelType:fallbackChannelType];
+    it.messageKind = WKCHS_ParseMessageKind(WKCHS_String(dict[@"message_kind"]));
+    it.snippet = WKCHS_String(dict[@"snippet"]);
+    it.matchReason = WKCHS_String(dict[@"match_reason"]);
+    // 合并转发 outer_preview
+    NSDictionary *outer = WKCHS_Dict(dict[@"outer_preview"]);
+    if (outer) {
+        it.forwardTitle = WKCHS_String(outer[@"title"]);
+        it.forwardChildCount = WKCHS_Int(outer[@"child_count"]);
+        NSDictionary *quoted = WKCHS_Dict(outer[@"quoted"]);
+        if (quoted) {
+            it.quotedSenderName = WKCHS_String(quoted[@"sender_name"]);
+            NSString *qt = WKCHS_String(quoted[@"text"]);
+            if (qt.length == 0) qt = WKCHS_String(quoted[@"placeholder"]);
+            it.quotedText = qt;
+        }
+    }
+    it.innerMessages = WKCHS_Array(dict[@"inner_messages"]);
+    // rich_text.plain 兜底 (与 web hit.rich_text.plain 同口径)
+    NSDictionary *richText = WKCHS_Dict(dict[@"rich_text"]);
+    if (richText) {
+        it.richTextPlain = WKCHS_String(richText[@"plain"]);
+        // plain 也没有时, 拼所有 content[].text 作为二次兜底
+        if (it.richTextPlain.length == 0) {
+            NSArray *blocks = WKCHS_Array(richText[@"content"]);
+            if (blocks.count > 0) {
+                NSMutableString *joined = [NSMutableString string];
+                for (NSDictionary *b in blocks) {
+                    if (![b isKindOfClass:[NSDictionary class]]) continue;
+                    NSString *t = WKCHS_String(b[@"text"]);
+                    if (t.length > 0) [joined appendString:t];
+                }
+                if (joined.length > 0) it.richTextPlain = joined;
+            }
+        }
+    }
+    // 富文本/图片消息可能带 thumb_url / 尺寸
+    it.thumbUrl = WKCHS_String(dict[@"thumb_url"]);
+    it.width = WKCHS_Int(dict[@"width"]);
+    it.height = WKCHS_Int(dict[@"height"]);
+    it.durationMs = WKCHS_Int(dict[@"duration_ms"]);
+    return it;
+}
+
++ (instancetype)mediaItemFromDict:(NSDictionary *)dict
+                     fallbackChannelId:(nullable NSString *)fallbackChannelId
+                   fallbackChannelType:(NSInteger)fallbackChannelType {
+    WKChannelHistorySearchItem *it = [WKChannelHistorySearchItem new];
+    it.kind = WKChannelHistorySearchItemKindMedia;
+    [it applyCommonFromDict:dict
+              fallbackChannelId:fallbackChannelId
+            fallbackChannelType:fallbackChannelType];
+    it.mediaKind = WKCHS_ParseMediaKind(WKCHS_String(dict[@"media_kind"]));
+    it.thumbUrl = WKCHS_String(dict[@"thumb_url"]);
+    // 大文件原始 URL — 服务端字段名因接口/版本有差异, 尽量穷举常见命名以提高命中率。
+    // 命中顺序: 严格的 url / media_url → 按 kind 区分的 image_url / video_url
+    // → 流式播放专用 play_url / m3u8_url → 通用 file_url / source_url
+    // → 兜底 download_url。
+    NSString *url = WKCHS_String(dict[@"url"]);
+    if (url.length == 0) url = WKCHS_String(dict[@"media_url"]);
+    if (url.length == 0) {
+        if (it.mediaKind == WKChannelHistorySearchMediaKindVideo) {
+            url = WKCHS_String(dict[@"video_url"]);
+            if (url.length == 0) url = WKCHS_String(dict[@"play_url"]);
+            if (url.length == 0) url = WKCHS_String(dict[@"m3u8_url"]);
+        } else {
+            url = WKCHS_String(dict[@"image_url"]);
+            if (url.length == 0) url = WKCHS_String(dict[@"img_url"]);
+        }
+    }
+    if (url.length == 0) url = WKCHS_String(dict[@"file_url"]);
+    if (url.length == 0) url = WKCHS_String(dict[@"source_url"]);
+    if (url.length == 0) url = WKCHS_String(dict[@"download_url"]);
+    it.originalUrl = url;
+    it.previewUrl = WKCHS_String(dict[@"preview_url"]);
+    it.width = WKCHS_Int(dict[@"width"]);
+    it.height = WKCHS_Int(dict[@"height"]);
+    it.durationMs = WKCHS_Int(dict[@"duration_ms"]);
+    it.monthBucket = WKCHS_String(dict[@"month_bucket"]);
+    return it;
+}
+
++ (instancetype)fileItemFromDict:(NSDictionary *)dict
+                    fallbackChannelId:(nullable NSString *)fallbackChannelId
+                  fallbackChannelType:(NSInteger)fallbackChannelType {
+    WKChannelHistorySearchItem *it = [WKChannelHistorySearchItem new];
+    it.kind = WKChannelHistorySearchItemKindFile;
+    [it applyCommonFromDict:dict
+              fallbackChannelId:fallbackChannelId
+            fallbackChannelType:fallbackChannelType];
+    it.fileName = WKCHS_String(dict[@"file_name"]);
+    it.fileSizeBytes = WKCHS_Int64(dict[@"file_size_bytes"]);
+    it.fileExt = WKCHS_String(dict[@"file_ext"]);
+    it.fileDownloadUrl = WKCHS_String(dict[@"download_url"]);
+    it.filePreviewUrl = WKCHS_String(dict[@"preview_url"]);
+    return it;
+}
+
++ (nullable instancetype)combinedItemFromDict:(NSDictionary *)dict
+                                  fallbackChannelId:(nullable NSString *)fallbackChannelId
+                                fallbackChannelType:(NSInteger)fallbackChannelType {
+    NSString *rt = WKCHS_String(dict[@"result_type"]);
+    NSString *sortedAt = WKCHS_String(dict[@"sorted_at"]);
+    WKChannelHistorySearchItem *it = nil;
+    if ([rt isEqualToString:@"message"]) {
+        NSDictionary *m = WKCHS_Dict(dict[@"message"]);
+        if (m) it = [self messageItemFromDict:m
+                              fallbackChannelId:fallbackChannelId
+                            fallbackChannelType:fallbackChannelType];
+    } else if ([rt isEqualToString:@"file"]) {
+        NSDictionary *m = WKCHS_Dict(dict[@"file"]);
+        if (m) it = [self fileItemFromDict:m
+                            fallbackChannelId:fallbackChannelId
+                          fallbackChannelType:fallbackChannelType];
+    } else if ([rt isEqualToString:@"media"]) {
+        NSDictionary *m = WKCHS_Dict(dict[@"media"]);
+        if (m) it = [self mediaItemFromDict:m
+                            fallbackChannelId:fallbackChannelId
+                          fallbackChannelType:fallbackChannelType];
+    }
+    if (it) it.sortedAtRaw = sortedAt;
+    return it;
+}
+
+@end
+
+#pragma mark - Page
+
+@implementation WKChannelHistorySearchPage
+
++ (instancetype)pageFromResponse:(id)response
+                              tab:(WKChannelHistorySearchTab)tab
+                     channelId:(nullable NSString *)channelId
+                   channelType:(NSInteger)channelType {
+    WKChannelHistorySearchPage *page = [WKChannelHistorySearchPage new];
+    page.items = @[];
+    page.hasMore = NO;
+    page.nextCursor = nil;
+
+    NSArray *rawList = nil;
+    if ([response isKindOfClass:[NSArray class]]) {
+        rawList = response;
+    } else if ([response isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dict = (NSDictionary *)response;
+        // 兼容 data / items / list 几种命名（web 用 data，旧接口用 items / list）
+        id list = dict[@"data"];
+        if (![list isKindOfClass:[NSArray class]]) list = dict[@"items"];
+        if (![list isKindOfClass:[NSArray class]]) list = dict[@"list"];
+        if ([list isKindOfClass:[NSArray class]]) rawList = list;
+        NSDictionary *pg = WKCHS_Dict(dict[@"pagination"]);
+        if (pg) {
+            id hm = pg[@"has_more"];
+            page.hasMore = [hm respondsToSelector:@selector(boolValue)] ? [hm boolValue] : NO;
+            page.nextCursor = WKCHS_String(pg[@"next_cursor"]);
+        } else {
+            // 兼容旧风格 has_more / next_cursor 直接挂在外层
+            id hm = dict[@"has_more"];
+            if ([hm respondsToSelector:@selector(boolValue)]) page.hasMore = [hm boolValue];
+            NSString *nc = WKCHS_String(dict[@"next_cursor"]);
+            if (nc.length > 0) page.nextCursor = nc;
+        }
+    }
+
+    if (![rawList isKindOfClass:[NSArray class]]) {
+        return page;
+    }
+    NSMutableArray<WKChannelHistorySearchItem *> *items = [NSMutableArray arrayWithCapacity:rawList.count];
+    for (NSDictionary *dict in rawList) {
+        if (![dict isKindOfClass:[NSDictionary class]]) continue;
+        WKChannelHistorySearchItem *it = nil;
+        switch (tab) {
+            case WKChannelHistorySearchTabAll:
+                it = [WKChannelHistorySearchItem combinedItemFromDict:dict
+                                                  fallbackChannelId:channelId
+                                                fallbackChannelType:channelType];
+                break;
+            case WKChannelHistorySearchTabMessage:
+                it = [WKChannelHistorySearchItem messageItemFromDict:dict
+                                                 fallbackChannelId:channelId
+                                               fallbackChannelType:channelType];
+                break;
+            case WKChannelHistorySearchTabMedia:
+                it = [WKChannelHistorySearchItem mediaItemFromDict:dict
+                                               fallbackChannelId:channelId
+                                             fallbackChannelType:channelType];
+                break;
+            case WKChannelHistorySearchTabFile:
+                it = [WKChannelHistorySearchItem fileItemFromDict:dict
+                                              fallbackChannelId:channelId
+                                            fallbackChannelType:channelType];
+                break;
+        }
+        if (it) [items addObject:it];
+    }
+    page.items = items;
+    return page;
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFileCell.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFileCell.h
@@ -1,0 +1,23 @@
+//
+//  WKChannelHistoryFileCell.h
+//  WuKongBase
+//
+//  搜索结果 — 文件行。用于"全部" tab（内嵌）和"文件" tab。
+//  样式：左侧文件类型小图标（圆角方形）+ 右侧两行（文件名 [高亮] / 发送人 · 大小 · 时间）。
+//
+
+#import <UIKit/UIKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryFileCell : UITableViewCell
+
++ (NSString *)reuseIdentifier;
++ (CGFloat)cellHeight;
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(nullable NSString *)keyword;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFileCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFileCell.m
@@ -1,0 +1,126 @@
+//
+//  WKChannelHistoryFileCell.m
+//
+
+#import "WKChannelHistoryFileCell.h"
+#import "WKChannelHistoryHighlighter.h"
+#import "WKApp.h"
+#import "WKTimeTool.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+
+#define kFileCellHeight 72.0f
+#define kIconSize       40.0f
+#define kHPadding       16.0f
+#define kGap            12.0f
+
+@interface WKChannelHistoryFileCell ()
+@property (nonatomic, strong) UILabel *iconLbl;       // 文件后缀字符显示
+@property (nonatomic, strong) UIView *iconBg;
+@property (nonatomic, strong) UILabel *nameLbl;
+@property (nonatomic, strong) UILabel *metaLbl;
+@property (nonatomic, strong) UIView *separator;
+@end
+
+@implementation WKChannelHistoryFileCell
+
++ (NSString *)reuseIdentifier { return NSStringFromClass(self); }
++ (CGFloat)cellHeight { return kFileCellHeight; }
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+
+        _iconBg = [UIView new];
+        _iconBg.layer.cornerRadius = 6.0f;
+        _iconBg.backgroundColor = [[WKApp shared].config.themeColor colorWithAlphaComponent:0.12];
+        [self.contentView addSubview:_iconBg];
+
+        _iconLbl = [UILabel new];
+        _iconLbl.font = [[WKApp shared].config appFontOfSize:11.0f];
+        _iconLbl.textColor = [WKApp shared].config.themeColor;
+        _iconLbl.textAlignment = NSTextAlignmentCenter;
+        [_iconBg addSubview:_iconLbl];
+
+        _nameLbl = [UILabel new];
+        _nameLbl.font = [[WKApp shared].config appFontOfSize:15.0f];
+        _nameLbl.textColor = [WKApp shared].config.defaultTextColor;
+        _nameLbl.numberOfLines = 1;
+        _nameLbl.lineBreakMode = NSLineBreakByTruncatingMiddle;
+        [self.contentView addSubview:_nameLbl];
+
+        _metaLbl = [UILabel new];
+        _metaLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+        _metaLbl.textColor = [UIColor grayColor];
+        _metaLbl.numberOfLines = 1;
+        _metaLbl.lineBreakMode = NSLineBreakByTruncatingTail;
+        [self.contentView addSubview:_metaLbl];
+
+        _separator = [UIView new];
+        _separator.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.12];
+        [self.contentView addSubview:_separator];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat w = self.contentView.lim_width;
+    CGFloat h = self.contentView.lim_height;
+    self.iconBg.frame = CGRectMake(kHPadding, (h - kIconSize) / 2.0f, kIconSize, kIconSize);
+    self.iconLbl.frame = self.iconBg.bounds;
+    CGFloat textX = CGRectGetMaxX(self.iconBg.frame) + kGap;
+    CGFloat textW = w - textX - kHPadding;
+    self.nameLbl.frame = CGRectMake(textX, 16.0f, textW, 20.0f);
+    self.metaLbl.frame = CGRectMake(textX, CGRectGetMaxY(self.nameLbl.frame) + 4.0f, textW, 16.0f);
+    self.separator.frame = CGRectMake(textX, h - 0.5f, w - textX, 0.5f);
+}
+
+- (NSString *)humanReadableFileSize:(long long)bytes {
+    if (bytes <= 0) return @"";
+    double size = (double)bytes;
+    NSArray *units = @[@"B", @"KB", @"MB", @"GB", @"TB"];
+    NSUInteger idx = 0;
+    while (size >= 1024.0 && idx < units.count - 1) {
+        size /= 1024.0;
+        idx++;
+    }
+    if (idx == 0) return [NSString stringWithFormat:@"%lld %@", bytes, units[0]];
+    return [NSString stringWithFormat:@"%.1f %@", size, units[idx]];
+}
+
+- (NSString *)iconBadgeFromExt:(NSString *)ext fileName:(NSString *)name {
+    NSString *e = ext.length > 0 ? [ext lowercaseString] : nil;
+    if (e.length == 0 && name.length > 0) {
+        NSString *trimmed = [name stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        NSRange dot = [trimmed rangeOfString:@"." options:NSBackwardsSearch];
+        if (dot.location != NSNotFound && dot.location + 1 < trimmed.length) {
+            e = [[trimmed substringFromIndex:dot.location + 1] lowercaseString];
+        }
+    }
+    if (e.length == 0) return @"FILE";
+    if (e.length > 4) e = [e substringToIndex:4];
+    return [e uppercaseString];
+}
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(NSString *)keyword {
+    UIColor *theme = [WKApp shared].config.themeColor;
+    self.iconLbl.text = [self iconBadgeFromExt:item.fileExt fileName:item.fileName];
+    self.nameLbl.attributedText = [WKChannelHistoryHighlighter attributedFromSnippet:(item.fileName ?: @"")
+                                                                                 keyword:keyword
+                                                                                    font:self.nameLbl.font
+                                                                               textColor:[WKApp shared].config.defaultTextColor
+                                                                          highlightColor:theme];
+    NSMutableArray<NSString *> *metaParts = [NSMutableArray array];
+    if (item.senderName.length > 0) [metaParts addObject:item.senderName];
+    NSString *sz = [self humanReadableFileSize:item.fileSizeBytes];
+    if (sz.length > 0) [metaParts addObject:sz];
+    if (item.timestamp > 0) {
+        [metaParts addObject:[WKTimeTool searchResultTimeString:[NSDate dateWithTimeIntervalSince1970:item.timestamp]]];
+    }
+    self.metaLbl.text = [metaParts componentsJoinedByString:@" · "];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.h
@@ -1,0 +1,26 @@
+//
+//  WKChannelHistoryFilterChipBar.h
+//  WuKongBase
+//
+//  搜索页顶部"筛选 chip 行"：横向滚动 chip 列表，单个 chip 含图标+文字+✕。
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// 单个 chip 描述。
+@interface WKChannelHistoryFilterChipDescriptor : NSObject
+@property (nonatomic, copy) NSString *key;          // 'sender' / 'date' / 'sort'
+@property (nonatomic, copy) NSString *title;        // 显示文本
+@property (nonatomic, copy, nullable) void(^onClear)(void);
+@property (nonatomic, copy, nullable) void(^onTap)(void);
+@end
+
+@interface WKChannelHistoryFilterChipBar : UIView
+
+@property (nonatomic, copy) NSArray<WKChannelHistoryFilterChipDescriptor *> *chips;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.m
@@ -1,0 +1,101 @@
+//
+//  WKChannelHistoryFilterChipBar.m
+//
+
+#import "WKChannelHistoryFilterChipBar.h"
+#import "WKApp.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+#import <objc/runtime.h>
+
+@implementation WKChannelHistoryFilterChipDescriptor
+@end
+
+@interface WKChannelHistoryFilterChipBar ()
+@property (nonatomic, strong) UIScrollView *scrollView;
+@end
+
+@implementation WKChannelHistoryFilterChipBar
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [WKApp shared].config.backgroundColor;
+        _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+        _scrollView.showsHorizontalScrollIndicator = NO;
+        _scrollView.alwaysBounceHorizontal = YES;
+        [self addSubview:_scrollView];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.scrollView.frame = self.bounds;
+    [self relayoutChips];
+}
+
+- (void)setChips:(NSArray<WKChannelHistoryFilterChipDescriptor *> *)chips {
+    _chips = [chips copy];
+    [self relayoutChips];
+}
+
+- (void)relayoutChips {
+    for (UIView *sub in [self.scrollView.subviews copy]) [sub removeFromSuperview];
+    CGFloat x = 12.0f;
+    CGFloat h = self.lim_height > 0 ? self.lim_height : 32.0f;
+    UIColor *theme = [WKApp shared].config.themeColor;
+    UIColor *bg = [theme colorWithAlphaComponent:0.10];
+    UIFont *font = [[WKApp shared].config appFontOfSize:12.0f];
+    for (WKChannelHistoryFilterChipDescriptor *d in self.chips) {
+        // 容器
+        UIControl *chip = [[UIControl alloc] init];
+        chip.backgroundColor = bg;
+        chip.layer.cornerRadius = (h - 12.0f) / 2.0f;
+        chip.layer.masksToBounds = YES;
+        [chip addTarget:self action:@selector(onChipTap:) forControlEvents:UIControlEventTouchUpInside];
+        chip.tag = [self.chips indexOfObject:d];
+
+        // 文本
+        UILabel *lbl = [UILabel new];
+        lbl.text = d.title ?: @"";
+        lbl.font = font;
+        lbl.textColor = theme;
+        [chip addSubview:lbl];
+        CGFloat textW = [lbl sizeThatFits:CGSizeMake(220.0f, h)].width;
+        lbl.frame = CGRectMake(10.0f, 0, textW, h - 12.0f);
+
+        // ✕ 按钮
+        UIButton *clr = [UIButton buttonWithType:UIButtonTypeSystem];
+        clr.titleLabel.font = [UIFont systemFontOfSize:13.0f weight:UIFontWeightMedium];
+        [clr setTitle:@"✕" forState:UIControlStateNormal];
+        [clr setTitleColor:theme forState:UIControlStateNormal];
+        clr.frame = CGRectMake(CGRectGetMaxX(lbl.frame) + 4.0f, 0, 24.0f, h - 12.0f);
+        // 用 block 持久持有 onClear
+        WKChannelHistoryFilterChipDescriptor *desc = d;
+        [clr addTarget:self action:@selector(onChipClearProxy:) forControlEvents:UIControlEventTouchUpInside];
+        objc_setAssociatedObject(clr, _cmd, desc, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [chip addSubview:clr];
+
+        CGFloat chipW = CGRectGetMaxX(clr.frame) + 8.0f;
+        chip.frame = CGRectMake(x, 6.0f, chipW, h - 12.0f);
+        [self.scrollView addSubview:chip];
+        x = CGRectGetMaxX(chip.frame) + 8.0f;
+    }
+    self.scrollView.contentSize = CGSizeMake(x + 4.0f, h);
+}
+
+- (void)onChipTap:(UIControl *)sender {
+    NSInteger idx = sender.tag;
+    if (idx < 0 || idx >= (NSInteger)self.chips.count) return;
+    WKChannelHistoryFilterChipDescriptor *d = self.chips[idx];
+    if (d.onTap) d.onTap();
+}
+
+- (void)onChipClearProxy:(UIButton *)btn {
+    WKChannelHistoryFilterChipDescriptor *d = objc_getAssociatedObject(btn, @selector(onChipTap:));
+    if (!d) return;
+    if (d.onClear) d.onClear();
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryFilterChipBar.m
@@ -8,6 +8,12 @@
 #import "WuKongBase.h"
 #import <objc/runtime.h>
 
+// 用于把 chip descriptor 绑到 ✕ 按钮上的关联对象 key。老实现 set 用 `_cmd`
+// (= relayoutChips) 而 get 用 @selector(onChipTap:), 两把钥匙不匹配 →
+// getAssociatedObject 恒返 nil → ✕ 清除按钮点了没反应 (PR #64 review 3 位 reviewer 独立命中)。
+// 用一个 static const void * 统一 key 避免再犯。
+static const void * const kWKChipDescKey = &kWKChipDescKey;
+
 @implementation WKChannelHistoryFilterChipDescriptor
 @end
 
@@ -74,7 +80,7 @@
         // 用 block 持久持有 onClear
         WKChannelHistoryFilterChipDescriptor *desc = d;
         [clr addTarget:self action:@selector(onChipClearProxy:) forControlEvents:UIControlEventTouchUpInside];
-        objc_setAssociatedObject(clr, _cmd, desc, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(clr, kWKChipDescKey, desc, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         [chip addSubview:clr];
 
         CGFloat chipW = CGRectGetMaxX(clr.frame) + 8.0f;
@@ -93,7 +99,7 @@
 }
 
 - (void)onChipClearProxy:(UIButton *)btn {
-    WKChannelHistoryFilterChipDescriptor *d = objc_getAssociatedObject(btn, @selector(onChipTap:));
+    WKChannelHistoryFilterChipDescriptor *d = objc_getAssociatedObject(btn, kWKChipDescKey);
     if (!d) return;
     if (d.onClear) d.onClear();
 }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.h
@@ -1,0 +1,18 @@
+//
+//  WKChannelHistoryMediaGridCell.h
+//  WuKongBase
+//
+//  "图片视频" tab 网格 cell。九宫格风格（3 列）+ 视频时长角标。
+//
+
+#import <UIKit/UIKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryMediaGridCell : UICollectionViewCell
++ (NSString *)reuseIdentifier;
+- (void)applyItem:(WKChannelHistorySearchItem *)item;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.m
@@ -1,0 +1,97 @@
+//
+//  WKChannelHistoryMediaGridCell.m
+//
+
+#import "WKChannelHistoryMediaGridCell.h"
+#import "WKApp.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+#import <SDWebImage/SDWebImage.h>
+
+@interface WKChannelHistoryMediaGridCell ()
+@property (nonatomic, strong) UIImageView *thumbView;
+@property (nonatomic, strong) UIView *videoOverlay;    // 视频底部渐变背景
+@property (nonatomic, strong) UILabel *durationLbl;    // 时长 mm:ss
+@property (nonatomic, strong) UIView *playBadge;       // 视频中心播放标
+@end
+
+@implementation WKChannelHistoryMediaGridCell
+
++ (NSString *)reuseIdentifier { return NSStringFromClass(self); }
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.contentView.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.08];
+        self.contentView.clipsToBounds = YES;
+
+        _thumbView = [UIImageView new];
+        _thumbView.contentMode = UIViewContentModeScaleAspectFill;
+        _thumbView.clipsToBounds = YES;
+        [self.contentView addSubview:_thumbView];
+
+        _videoOverlay = [UIView new];
+        _videoOverlay.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.35];
+        _videoOverlay.hidden = YES;
+        [self.contentView addSubview:_videoOverlay];
+
+        _durationLbl = [UILabel new];
+        _durationLbl.font = [UIFont systemFontOfSize:10.0f];
+        _durationLbl.textColor = [UIColor whiteColor];
+        _durationLbl.textAlignment = NSTextAlignmentRight;
+        _durationLbl.hidden = YES;
+        [self.contentView addSubview:_durationLbl];
+
+        _playBadge = [UIView new];
+        _playBadge.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.45];
+        _playBadge.layer.cornerRadius = 16.0f;
+        _playBadge.layer.masksToBounds = YES;
+        _playBadge.hidden = YES;
+        UILabel *tri = [UILabel new];
+        tri.text = @"▶";
+        tri.textColor = [UIColor whiteColor];
+        tri.font = [UIFont systemFontOfSize:14.0f];
+        tri.textAlignment = NSTextAlignmentCenter;
+        tri.frame = CGRectMake(0, 0, 32, 32);
+        [_playBadge addSubview:tri];
+        [self.contentView addSubview:_playBadge];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.thumbView.frame = self.contentView.bounds;
+    CGFloat w = self.contentView.lim_width;
+    CGFloat h = self.contentView.lim_height;
+    self.videoOverlay.frame = CGRectMake(0, h - 18.0f, w, 18.0f);
+    self.durationLbl.frame = CGRectMake(0, h - 16.0f, w - 4.0f, 14.0f);
+    self.playBadge.frame = CGRectMake((w - 32.0f) / 2.0f, (h - 32.0f) / 2.0f, 32.0f, 32.0f);
+}
+
+- (NSString *)durationStringFromMs:(NSInteger)ms {
+    if (ms <= 0) return @"";
+    NSInteger sec = ms / 1000;
+    NSInteger m = sec / 60;
+    NSInteger s = sec % 60;
+    return [NSString stringWithFormat:@"%ld:%02ld", (long)m, (long)s];
+}
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item {
+    NSString *url = item.thumbUrl.length > 0 ? item.thumbUrl : item.previewUrl;
+    if (url.length == 0) url = item.originalUrl;
+    if (url.length > 0) {
+        [self.thumbView sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:nil];
+    } else {
+        self.thumbView.image = nil;
+    }
+    BOOL isVideo = item.mediaKind == WKChannelHistorySearchMediaKindVideo;
+    self.videoOverlay.hidden = !isVideo;
+    self.durationLbl.hidden = !isVideo;
+    self.playBadge.hidden = !isVideo;
+    if (isVideo) {
+        self.durationLbl.text = [self durationStringFromMs:item.durationMs];
+    }
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaGridCell.m
@@ -81,7 +81,11 @@
     NSString *url = item.thumbUrl.length > 0 ? item.thumbUrl : item.previewUrl;
     if (url.length == 0) url = item.originalUrl;
     if (url.length > 0) {
-        [self.thumbView sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:nil];
+        // 服务端返回的 URL 可能是相对路径, 走 WKApp.getImageFullUrl: 拼 apiBaseUrl,
+        // 与同模块 WKChannelHistoryMediaBrowser.resolveRemoteURL: 同口径 (PR #64 review
+        // yujiawei 命中: cells 直接 URLWithString 导致相对 URL thumb 空白, 但 browser
+        // 打开又能显示)。
+        [self.thumbView sd_setImageWithURL:[[WKApp shared] getImageFullUrl:url] placeholderImage:nil];
     } else {
         self.thumbView.image = nil;
     }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.h
@@ -1,0 +1,22 @@
+//
+//  WKChannelHistoryMediaRowCell.h
+//  WuKongBase
+//
+//  "全部" tab 中混排媒体命中：左侧 56×56 缩略图 + 右侧两行（发送人 / 时间 + 命中理由）。
+//
+
+#import <UIKit/UIKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryMediaRowCell : UITableViewCell
+
++ (NSString *)reuseIdentifier;
++ (CGFloat)cellHeight;
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(nullable NSString *)keyword;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.m
@@ -103,7 +103,8 @@
     NSString *thumb = item.thumbUrl.length > 0 ? item.thumbUrl : item.previewUrl;
     if (thumb.length == 0) thumb = item.originalUrl;
     if (thumb.length > 0) {
-        [self.thumbView sd_setImageWithURL:[NSURL URLWithString:thumb]
+        // 见 WKChannelHistoryMediaGridCell.m 同源注释, 走 getImageFullUrl: 兜相对 URL。
+        [self.thumbView sd_setImageWithURL:[[WKApp shared] getImageFullUrl:thumb]
                           placeholderImage:nil];
     } else {
         self.thumbView.image = nil;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMediaRowCell.m
@@ -1,0 +1,114 @@
+//
+//  WKChannelHistoryMediaRowCell.m
+//
+
+#import "WKChannelHistoryMediaRowCell.h"
+#import "WKChannelHistoryHighlighter.h"
+#import "WKApp.h"
+#import "WKTimeTool.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+#import <SDWebImage/SDWebImage.h>
+
+#define kRowMediaHeight 88.0f
+#define kThumbSize      56.0f
+#define kHPadding       16.0f
+#define kGap            12.0f
+
+@interface WKChannelHistoryMediaRowCell ()
+@property (nonatomic, strong) UIImageView *thumbView;
+@property (nonatomic, strong) UIImageView *playBadge;       // 视频角标
+@property (nonatomic, strong) UILabel *nameLbl;
+@property (nonatomic, strong) UILabel *metaLbl;
+@property (nonatomic, strong) UIView *separator;
+@end
+
+@implementation WKChannelHistoryMediaRowCell
+
++ (NSString *)reuseIdentifier { return NSStringFromClass(self); }
++ (CGFloat)cellHeight { return kRowMediaHeight; }
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+
+        _thumbView = [UIImageView new];
+        _thumbView.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.08];
+        _thumbView.layer.cornerRadius = 6.0f;
+        _thumbView.layer.masksToBounds = YES;
+        _thumbView.contentMode = UIViewContentModeScaleAspectFill;
+        [self.contentView addSubview:_thumbView];
+
+        _playBadge = [UIImageView new];
+        _playBadge.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
+        _playBadge.layer.cornerRadius = 12.0f;
+        _playBadge.layer.masksToBounds = YES;
+        _playBadge.hidden = YES;
+        // 用 unicode 三角形占位（与项目其它地方对视频角标的简化处理一致；如需自定义图标可改 image）
+        UILabel *tri = [UILabel new];
+        tri.text = @"▶";
+        tri.textColor = [UIColor whiteColor];
+        tri.font = [UIFont systemFontOfSize:12.0f];
+        tri.textAlignment = NSTextAlignmentCenter;
+        tri.frame = CGRectMake(0, 0, 24, 24);
+        [_playBadge addSubview:tri];
+        [self.contentView addSubview:_playBadge];
+
+        _nameLbl = [UILabel new];
+        _nameLbl.font = [[WKApp shared].config appFontOfSize:15.0f];
+        _nameLbl.textColor = [WKApp shared].config.defaultTextColor;
+        [self.contentView addSubview:_nameLbl];
+
+        _metaLbl = [UILabel new];
+        _metaLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+        _metaLbl.textColor = [UIColor grayColor];
+        _metaLbl.numberOfLines = 1;
+        _metaLbl.lineBreakMode = NSLineBreakByTruncatingTail;
+        [self.contentView addSubview:_metaLbl];
+
+        _separator = [UIView new];
+        _separator.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.12];
+        [self.contentView addSubview:_separator];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat w = self.contentView.lim_width;
+    CGFloat h = self.contentView.lim_height;
+    self.thumbView.frame = CGRectMake(kHPadding, (h - kThumbSize) / 2.0f, kThumbSize, kThumbSize);
+    self.playBadge.frame = CGRectMake(CGRectGetMaxX(self.thumbView.frame) - 24.0f - 4.0f,
+                                       CGRectGetMaxY(self.thumbView.frame) - 24.0f - 4.0f,
+                                       24.0f, 24.0f);
+    CGFloat textX = CGRectGetMaxX(self.thumbView.frame) + kGap;
+    CGFloat textW = w - textX - kHPadding;
+    self.nameLbl.frame = CGRectMake(textX, (h / 2.0f) - 22.0f, textW, 20.0f);
+    self.metaLbl.frame = CGRectMake(textX, (h / 2.0f) + 2.0f, textW, 16.0f);
+    self.separator.frame = CGRectMake(textX, h - 0.5f, w - textX, 0.5f);
+}
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(NSString *)keyword {
+    self.nameLbl.text = item.senderName.length > 0 ? item.senderName : @" ";
+    NSMutableArray *meta = [NSMutableArray array];
+    NSString *kindLbl = item.mediaKind == WKChannelHistorySearchMediaKindVideo ? LLang(@"视频") : LLang(@"图片");
+    [meta addObject:kindLbl];
+    if (item.timestamp > 0) {
+        [meta addObject:[WKTimeTool searchResultTimeString:[NSDate dateWithTimeIntervalSince1970:item.timestamp]]];
+    }
+    self.metaLbl.text = [meta componentsJoinedByString:@" · "];
+
+    NSString *thumb = item.thumbUrl.length > 0 ? item.thumbUrl : item.previewUrl;
+    if (thumb.length == 0) thumb = item.originalUrl;
+    if (thumb.length > 0) {
+        [self.thumbView sd_setImageWithURL:[NSURL URLWithString:thumb]
+                          placeholderImage:nil];
+    } else {
+        self.thumbView.image = nil;
+    }
+    self.playBadge.hidden = item.mediaKind != WKChannelHistorySearchMediaKindVideo;
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMessageCell.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMessageCell.h
@@ -1,0 +1,23 @@
+//
+//  WKChannelHistoryMessageCell.h
+//  WuKongBase
+//
+//  搜索结果 — 消息行（用于"全部" / "聊天记录" tab）。
+//  样式：左侧 36×36 圆形头像 + 右侧两行（标题：名 + 时间；内容：高亮 snippet）。
+//
+
+#import <UIKit/UIKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryMessageCell : UITableViewCell
+
++ (NSString *)reuseIdentifier;
++ (CGFloat)heightForItem:(WKChannelHistorySearchItem *)item width:(CGFloat)width;
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(nullable NSString *)keyword;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMessageCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistoryMessageCell.m
@@ -1,0 +1,451 @@
+//
+//  WKChannelHistoryMessageCell.m
+//
+
+#import "WKChannelHistoryMessageCell.h"
+#import "WKChannelHistoryHighlighter.h"
+#import "WKUserAvatar.h"
+#import "WKAvatarUtil.h"
+#import "WKApp.h"
+#import "WKTimeTool.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+
+#define kAvatarSize 36.0f
+#define kHPadding   16.0f
+#define kVPadding   12.0f
+#define kAvatarGap  10.0f
+#define kSnippetGap 4.0f
+// snippet 至少留出 2 行显示 (14pt system 单行 ~19pt)。原来是 34pt/一行半, UIKit 会
+// clip 掉第二行, 用户视觉只看到一行。改成 44pt 保 2 行渲染。
+#define kSnippetLineH 22.0f
+#define kSnippetLines 2
+// 合并转发卡片
+#define kCardHPadding 12.0f
+#define kCardVPadding 10.0f
+#define kCardIndent   12.0f   // 卡片相对左侧文本区的进一步缩进 (视觉上像"引用块")
+#define kCardCorner   8.0f
+#define kCardTitleH   20.0f
+#define kCardInnerLineH 20.0f
+#define kForwardInnerLimit 4
+// snippet 居中截断字符上限 — 兼顾 2 行渲染 (系统 14pt CJK 约 40 字, 拉丁 60+)。
+#define kSnippetCenterMaxLen 60
+
+static NSInteger WKCHS_ClampInt(NSInteger v, NSInteger lo, NSInteger hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+@interface WKChannelHistoryMessageCell ()
+@property (nonatomic, strong) WKUserAvatar *avatarView;
+@property (nonatomic, strong) UILabel *nameLbl;
+@property (nonatomic, strong) UILabel *timeLbl;
+@property (nonatomic, assign) CGFloat measuredTimeWidth; // 按实际字号测量, 避免固定宽度截断
+@property (nonatomic, strong) UILabel *snippetLbl;     // 非合并转发的主体内容, 最多 2 行
+@property (nonatomic, strong) UILabel *reasonLbl;      // 命中理由 (合并转发 / 富文本)
+@property (nonatomic, strong) UIView *separator;
+
+// 合并转发卡片
+@property (nonatomic, strong) UIView *forwardCardBg;
+@property (nonatomic, strong) UIView *forwardCardBar;   // 卡片左边 2pt 主题色竖条
+@property (nonatomic, strong) UILabel *forwardTitleLbl;
+@property (nonatomic, strong) NSMutableArray<UILabel *> *forwardInnerLbls;
+@property (nonatomic, strong) UILabel *forwardMoreLbl;
+@end
+
+@implementation WKChannelHistoryMessageCell
+
++ (NSString *)reuseIdentifier { return NSStringFromClass(self); }
+
+#pragma mark - height calc
+
++ (NSInteger)visibleInnerCountForItem:(WKChannelHistorySearchItem *)item {
+    return WKCHS_ClampInt((NSInteger)item.innerMessages.count, 0, kForwardInnerLimit);
+}
+
++ (NSInteger)hiddenInnerCountForItem:(WKChannelHistorySearchItem *)item visible:(NSInteger)visible {
+    NSInteger totalKnown = (NSInteger)item.innerMessages.count;
+    NSInteger childCount = item.forwardChildCount;
+    NSInteger total = (childCount > totalKnown) ? childCount : totalKnown;
+    return MAX(0, total - visible);
+}
+
++ (CGFloat)forwardCardHeightForItem:(WKChannelHistorySearchItem *)item {
+    NSInteger visible = [self visibleInnerCountForItem:item];
+    NSInteger hidden = [self hiddenInnerCountForItem:item visible:visible];
+    CGFloat h = kCardVPadding * 2;
+    h += kCardTitleH;               // 标题行
+    h += visible * kCardInnerLineH; // 前 N 条子消息
+    if (hidden > 0) h += kCardInnerLineH; // "还有 N 条聊天记录"
+    return h;
+}
+
++ (BOOL)itemNeedsReasonLine:(WKChannelHistorySearchItem *)item {
+    if (item.matchReason.length > 0) return YES;
+    if (item.messageKind == WKChannelHistorySearchMessageKindForward) return YES;
+    return NO;
+}
+
++ (CGFloat)heightForItem:(WKChannelHistorySearchItem *)item width:(CGFloat)width {
+    CGFloat h = kVPadding + 18.0f; // top padding + name line
+    if ([self itemNeedsReasonLine:item]) {
+        h += kSnippetGap + 16.0f;
+    }
+    if (item.messageKind == WKChannelHistorySearchMessageKindForward
+        && item.innerMessages.count > 0) {
+        h += 6.0f + [self forwardCardHeightForItem:item];
+    } else {
+        h += kSnippetGap + (kSnippetLineH * kSnippetLines);
+    }
+    h += kVPadding;
+    return h;
+}
+
+#pragma mark - init
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+
+        _avatarView = [[WKUserAvatar alloc] initWithFrame:CGRectMake(kHPadding, kVPadding, kAvatarSize, kAvatarSize)];
+        [self.contentView addSubview:_avatarView];
+
+        _nameLbl = [UILabel new];
+        _nameLbl.font = [[WKApp shared].config appFontOfSize:15.0f];
+        _nameLbl.textColor = [WKApp shared].config.defaultTextColor;
+        [self.contentView addSubview:_nameLbl];
+
+        _timeLbl = [UILabel new];
+        _timeLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+        _timeLbl.textColor = [UIColor grayColor];
+        _timeLbl.textAlignment = NSTextAlignmentRight;
+        [self.contentView addSubview:_timeLbl];
+
+        _reasonLbl = [UILabel new];
+        _reasonLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+        _reasonLbl.textColor = [UIColor grayColor];
+        _reasonLbl.numberOfLines = 1;
+        _reasonLbl.lineBreakMode = NSLineBreakByTruncatingTail;
+        [self.contentView addSubview:_reasonLbl];
+
+        _snippetLbl = [UILabel new];
+        _snippetLbl.font = [[WKApp shared].config appFontOfSize:14.0f];
+        _snippetLbl.textColor = [WKApp shared].config.defaultTextColor;
+        _snippetLbl.numberOfLines = kSnippetLines;
+        _snippetLbl.lineBreakMode = NSLineBreakByTruncatingTail;
+        [self.contentView addSubview:_snippetLbl];
+
+        [self setupForwardCard];
+
+        _separator = [UIView new];
+        _separator.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.12];
+        [self.contentView addSubview:_separator];
+    }
+    return self;
+}
+
+- (void)setupForwardCard {
+    _forwardCardBg = [UIView new];
+    _forwardCardBg.layer.cornerRadius = kCardCorner;
+    _forwardCardBg.layer.masksToBounds = YES;
+    _forwardCardBg.backgroundColor = [[WKApp shared].config.themeColor colorWithAlphaComponent:0.06];
+    _forwardCardBg.hidden = YES;
+    [self.contentView addSubview:_forwardCardBg];
+
+    _forwardCardBar = [UIView new];
+    _forwardCardBar.backgroundColor = [WKApp shared].config.themeColor;
+    [_forwardCardBg addSubview:_forwardCardBar];
+
+    _forwardTitleLbl = [UILabel new];
+    _forwardTitleLbl.font = [[WKApp shared].config appFontOfSize:13.0f];
+    _forwardTitleLbl.textColor = [WKApp shared].config.defaultTextColor;
+    _forwardTitleLbl.numberOfLines = 1;
+    _forwardTitleLbl.lineBreakMode = NSLineBreakByTruncatingTail;
+    [_forwardCardBg addSubview:_forwardTitleLbl];
+
+    _forwardInnerLbls = [NSMutableArray arrayWithCapacity:kForwardInnerLimit];
+    for (NSInteger i = 0; i < kForwardInnerLimit; i++) {
+        UILabel *l = [UILabel new];
+        l.font = [[WKApp shared].config appFontOfSize:12.0f];
+        l.textColor = [UIColor darkGrayColor];
+        l.numberOfLines = 1;
+        l.lineBreakMode = NSLineBreakByTruncatingTail;
+        [_forwardCardBg addSubview:l];
+        [_forwardInnerLbls addObject:l];
+    }
+
+    _forwardMoreLbl = [UILabel new];
+    _forwardMoreLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+    _forwardMoreLbl.textColor = [UIColor grayColor];
+    [_forwardCardBg addSubview:_forwardMoreLbl];
+}
+
+#pragma mark - layout
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat w = self.contentView.lim_width;
+    CGFloat h = self.contentView.lim_height;
+
+    self.avatarView.frame = CGRectMake(kHPadding, kVPadding, kAvatarSize, kAvatarSize);
+    CGFloat textX = CGRectGetMaxX(self.avatarView.frame) + kAvatarGap;
+    CGFloat textW = w - textX - kHPadding;
+
+    // time 按 applyItem 时预测的宽度定位, 保证 "yyyy-MM-dd HH:mm:ss" 完整可见。
+    // 名称行至少给 60pt (太窄的话回退到用一半剩余空间给时间, 避免名字完全被吞)。
+    CGFloat timeW = MIN(self.measuredTimeWidth, MAX(textW - 60.0f, 60.0f));
+    self.timeLbl.frame = CGRectMake(w - kHPadding - timeW, kVPadding + 2.0f, timeW, 16.0f);
+    self.nameLbl.frame = CGRectMake(textX, kVPadding, textW - timeW - 6.0f, 18.0f);
+
+    CGFloat cursorY = CGRectGetMaxY(self.nameLbl.frame) + kSnippetGap;
+    if (!self.reasonLbl.hidden) {
+        self.reasonLbl.frame = CGRectMake(textX, cursorY, textW, 16.0f);
+        cursorY = CGRectGetMaxY(self.reasonLbl.frame) + 2.0f;
+    }
+
+    if (!self.forwardCardBg.hidden) {
+        CGFloat cardX = textX + kCardIndent;
+        CGFloat cardW = w - cardX - kHPadding;
+        CGFloat cardH = h - cursorY - kVPadding;
+        self.forwardCardBg.frame = CGRectMake(cardX, cursorY + 4.0f, cardW, cardH - 4.0f);
+        [self layoutForwardCardContent];
+    } else {
+        CGFloat snippetH = h - cursorY - kVPadding;
+        if (snippetH < kSnippetLineH) snippetH = kSnippetLineH;
+        self.snippetLbl.frame = CGRectMake(textX, cursorY, textW, snippetH);
+    }
+
+    self.separator.frame = CGRectMake(textX, h - 0.5f, w - textX, 0.5f);
+}
+
+- (void)layoutForwardCardContent {
+    CGFloat w = self.forwardCardBg.lim_width;
+    CGFloat innerX = 2.0f + kCardHPadding;
+    CGFloat innerW = w - innerX - kCardHPadding;
+
+    self.forwardCardBar.frame = CGRectMake(0, 0, 2.0f, self.forwardCardBg.lim_height);
+
+    CGFloat y = kCardVPadding;
+    self.forwardTitleLbl.frame = CGRectMake(innerX, y, innerW, kCardTitleH);
+    y = CGRectGetMaxY(self.forwardTitleLbl.frame);
+
+    for (UILabel *l in self.forwardInnerLbls) {
+        if (l.hidden) continue;
+        l.frame = CGRectMake(innerX, y, innerW, kCardInnerLineH);
+        y = CGRectGetMaxY(l.frame);
+    }
+    if (!self.forwardMoreLbl.hidden) {
+        self.forwardMoreLbl.frame = CGRectMake(innerX, y, innerW, kCardInnerLineH);
+    }
+}
+
+#pragma mark - apply
+
+- (void)applyItem:(WKChannelHistorySearchItem *)item keyword:(NSString *)keyword {
+    UIColor *theme = [WKApp shared].config.themeColor;
+
+    self.nameLbl.text = item.senderName.length > 0 ? item.senderName : @" ";
+    NSString *timeStr = item.timestamp > 0
+        ? [WKTimeTool searchResultTimeString:[NSDate dateWithTimeIntervalSince1970:item.timestamp]]
+        : @"";
+    self.timeLbl.text = timeStr;
+    // 用实际字号预测时间宽度, 避免 "yyyy-MM-dd HH:mm:ss" (19 字) 被 72pt 硬截。
+    // ceil + 2pt 抗抖动 (Retina 字宽偶尔小数变化)。
+    CGSize tSize = [timeStr sizeWithAttributes:@{ NSFontAttributeName: self.timeLbl.font }];
+    self.measuredTimeWidth = timeStr.length > 0 ? ceil(tSize.width) + 2.0f : 0;
+    NSString *avatarUrl = nil;
+    if (item.senderAvatarUrl.length > 0) {
+        avatarUrl = [WKAvatarUtil getFullAvatarWIthPath:item.senderAvatarUrl];
+    } else if (item.senderId.length > 0) {
+        avatarUrl = [WKAvatarUtil getAvatar:item.senderId];
+    }
+    self.avatarView.url = avatarUrl;
+
+    BOOL isForward = (item.messageKind == WKChannelHistorySearchMessageKindForward);
+
+    // ----- reason 行 -----
+    NSString *reasonText = item.matchReason;
+    if (reasonText.length == 0 && isForward) {
+        // 合并转发 + 服务端没给 matchReason: 生成「转发聊天记录含"xx"」风格提示。
+        // 双引号在 Obj-C 字符串字面量里必须转义 (\"), 中文全角引号 "" 视觉上也可,
+        // 但 .strings key 保持转义 ASCII " 与字符串字面量一致, 免得两处对不上。
+        NSString *kw = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        reasonText = kw.length > 0
+            ? [NSString stringWithFormat:LLang(@"转发聊天记录含\"%@\""), kw]
+            : LLang(@"转发聊天记录");
+    }
+    if (reasonText.length > 0) {
+        self.reasonLbl.hidden = NO;
+        self.reasonLbl.attributedText = [WKChannelHistoryHighlighter attributedFromSnippet:reasonText
+                                                                                       keyword:keyword
+                                                                                          font:self.reasonLbl.font
+                                                                                     textColor:[UIColor grayColor]
+                                                                                highlightColor:theme];
+    } else {
+        self.reasonLbl.hidden = YES;
+        self.reasonLbl.text = nil;
+    }
+
+    // ----- 内容区: forward 卡片 vs 普通 snippet -----
+    if (isForward && item.innerMessages.count > 0) {
+        [self applyForwardCard:item keyword:keyword theme:theme];
+        self.snippetLbl.hidden = YES;
+        self.snippetLbl.text = nil;
+    } else {
+        self.forwardCardBg.hidden = YES;
+        self.snippetLbl.hidden = NO;
+        [self applyPlainSnippet:item keyword:keyword theme:theme];
+    }
+
+    [self setNeedsLayout];
+}
+
+- (void)applyPlainSnippet:(WKChannelHistorySearchItem *)item keyword:(NSString *)keyword theme:(UIColor *)theme {
+    NSString *snippetText = item.snippet ?: @"";
+    NSString *plainText = item.richTextPlain ?: @"";
+
+    // 命中源选择: 服务端有时会给两份文本 —
+    //   * snippet 是一段"默认预览" (可能只是消息开头/摘要片段, 不含关键词也不含 <mark>)
+    //   * rich_text.plain 是完整正文 (Markdown/富文本消息里带 <mark>关键词</mark> 的那份)
+    // 只按"snippet 非空就用 snippet"会漏掉 rich_text.plain 里真正命中关键词的正文,
+    // 导致 UI 里显示一段无关内容 (例如代码块开头) 而不是关键词附近。
+    // 按覆盖度排优先级 (与 web hit.snippet || rich_text.plain 相比是移动端专属优化):
+    //   1) snippet 含 <mark>          — 服务端已在 snippet 上明标, 最精准
+    //   2) plain   含 <mark>          — snippet 没标但 plain 里标了, 用 plain
+    //   3) snippet 含 keyword 文本    — 无 <mark> 但纯文本能匹配到关键词
+    //   4) plain   含 keyword 文本    — snippet 里没关键词, plain 里有
+    //   5) snippet 非空                — 都没匹配上, 显示 snippet 首段
+    //   6) plain   非空                — snippet 都空, 用 plain
+    NSString *kw = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    BOOL snippetHasMark = [snippetText rangeOfString:@"<mark>" options:NSCaseInsensitiveSearch].location != NSNotFound;
+    BOOL plainHasMark = [plainText rangeOfString:@"<mark>" options:NSCaseInsensitiveSearch].location != NSNotFound;
+    BOOL snippetHasKeyword = kw.length > 0 && !snippetHasMark
+        && [snippetText rangeOfString:kw options:NSCaseInsensitiveSearch].location != NSNotFound;
+    BOOL plainHasKeyword = kw.length > 0 && !plainHasMark
+        && [plainText rangeOfString:kw options:NSCaseInsensitiveSearch].location != NSNotFound;
+
+    NSString *snippet = nil;
+    if (snippetHasMark) snippet = snippetText;
+    else if (plainHasMark) snippet = plainText;
+    else if (snippetHasKeyword) snippet = snippetText;
+    else if (plainHasKeyword) snippet = plainText;
+    else if (snippetText.length > 0) snippet = snippetText;
+    else snippet = plainText;
+
+    // 引用消息回退: "@发送人: 引用内容"
+    if (snippet.length == 0
+        && item.messageKind == WKChannelHistorySearchMessageKindQuote
+        && item.quotedText.length > 0) {
+        snippet = item.quotedSenderName.length > 0
+            ? [NSString stringWithFormat:@"%@: %@", item.quotedSenderName, item.quotedText]
+            : item.quotedText;
+    }
+    // 合并转发无 inner_messages 时的最小兜底 (不会命中此分支, 上层已 isForward 分流)
+    if (snippet.length == 0 && item.messageKind == WKChannelHistorySearchMessageKindForward) {
+        if (item.forwardChildCount > 0) {
+            snippet = [NSString stringWithFormat:LLang(@"共 %ld 条记录"), (long)item.forwardChildCount];
+        }
+    }
+    if (snippet.length > 0) {
+        // 按 <mark> 位置 (或 keyword 位置) 做移动端友好的居中截 60 字, 之后交给高亮器渲染。
+        snippet = [WKChannelHistoryHighlighter centerSnippetFromServerText:snippet
+                                                                       keyword:keyword
+                                                                     maxLength:kSnippetCenterMaxLen];
+    }
+    self.snippetLbl.attributedText = [WKChannelHistoryHighlighter attributedFromText:snippet
+                                                                                keyword:keyword
+                                                                                   font:self.snippetLbl.font
+                                                                              textColor:[WKApp shared].config.defaultTextColor
+                                                                         highlightColor:theme];
+}
+
+#pragma mark - forward card
+
+- (void)applyForwardCard:(WKChannelHistorySearchItem *)item keyword:(NSString *)keyword theme:(UIColor *)theme {
+    self.forwardCardBg.hidden = NO;
+
+    // 标题: 服务端优先, 否则用子数量兜底
+    NSString *title = item.forwardTitle;
+    if (title.length == 0) {
+        title = item.forwardChildCount > 0
+            ? [NSString stringWithFormat:LLang(@"%ld条聊天记录"), (long)item.forwardChildCount]
+            : LLang(@"聊天记录");
+    }
+    self.forwardTitleLbl.attributedText = [WKChannelHistoryHighlighter attributedFromSnippet:title
+                                                                                         keyword:keyword
+                                                                                            font:self.forwardTitleLbl.font
+                                                                                       textColor:[WKApp shared].config.defaultTextColor
+                                                                                  highlightColor:theme];
+
+    NSInteger visible = [[self class] visibleInnerCountForItem:item];
+    for (NSInteger i = 0; i < kForwardInnerLimit; i++) {
+        UILabel *l = self.forwardInnerLbls[i];
+        if (i < visible) {
+            NSDictionary *msg = item.innerMessages[i];
+            NSString *line = [self formatInnerMessage:msg];
+            l.hidden = NO;
+            l.attributedText = [WKChannelHistoryHighlighter attributedFromSnippet:line
+                                                                              keyword:keyword
+                                                                                 font:l.font
+                                                                            textColor:[UIColor darkGrayColor]
+                                                                       highlightColor:theme];
+        } else {
+            l.hidden = YES;
+            l.attributedText = nil;
+        }
+    }
+
+    NSInteger hidden = [[self class] hiddenInnerCountForItem:item visible:visible];
+    if (hidden > 0) {
+        self.forwardMoreLbl.hidden = NO;
+        self.forwardMoreLbl.text = [NSString stringWithFormat:LLang(@"还有 %ld 条聊天记录"), (long)hidden];
+    } else {
+        self.forwardMoreLbl.hidden = YES;
+        self.forwardMoreLbl.text = nil;
+    }
+}
+
+/// 与 web forwardInnerMessage.formatForwardInnerMessage 同口径:
+///   1) 取 message.text (服务端 snippet, 可能含 <mark>), 缺失时按 type 输出占位
+///      (图片/视频/文件/普通消息)
+///   2) 若已经"senderName："开头则不重复拼, 否则前缀发送人名
+- (NSString *)formatInnerMessage:(NSDictionary *)msg {
+    if (![msg isKindOfClass:[NSDictionary class]]) return @"";
+    NSString *text = [self asString:msg[@"text"]];
+    if (text.length == 0) text = [self asString:msg[@"content"]];
+    if (text.length == 0) text = [self asString:msg[@"snippet"]];
+    if (text.length == 0) {
+        text = [self fallbackTextByType:msg];
+    }
+    NSString *senderName = [self asString:msg[@"sender_name"]];
+    if (senderName.length == 0) senderName = [self asString:msg[@"senderName"]];
+    if (senderName.length == 0) return text ?: @"";
+    // 已有 "senderName:" / "senderName：" 前缀则不重复拼
+    NSString *trimmedLead = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if ([trimmedLead hasPrefix:[NSString stringWithFormat:@"%@:", senderName]]
+        || [trimmedLead hasPrefix:[NSString stringWithFormat:@"%@：", senderName]]) {
+        return text;
+    }
+    return [NSString stringWithFormat:@"%@：%@", senderName, text];
+}
+
+- (NSString *)fallbackTextByType:(NSDictionary *)msg {
+    id t = msg[@"type"];
+    if (![t respondsToSelector:@selector(integerValue)]) t = msg[@"content_type"];
+    NSInteger type = [t respondsToSelector:@selector(integerValue)] ? [t integerValue] : 0;
+    // 与 WKConstant.h 保持: WK_IMAGE=2, WK_SMALLVIDEO=5, WK_FILE=6
+    if (type == 2) return LLang(@"[图片]");
+    if (type == 5) return LLang(@"[视频]");
+    if (type == 6) return LLang(@"[文件]");
+    return LLang(@"[聊天记录]");
+}
+
+- (NSString *)asString:(id)v {
+    if ([v isKindOfClass:[NSString class]]) return (NSString *)v;
+    return @"";
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistorySearchEmptyView.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistorySearchEmptyView.h
@@ -1,0 +1,33 @@
+//
+//  WKChannelHistorySearchEmptyView.h
+//  WuKongBase
+//
+//  搜索页中部占位视图：等待输入 / 无结果 / 加载中 / 加载失败 / 离线。
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, WKChannelHistorySearchEmptyMode) {
+    WKChannelHistorySearchEmptyModeWaitingInput = 0, // 未输入关键词且无筛选
+    WKChannelHistorySearchEmptyModeNoResults,        // 已搜索但无结果
+    WKChannelHistorySearchEmptyModeLoading,          // 首屏加载中
+    WKChannelHistorySearchEmptyModeError,            // 加载失败（含重试按钮）
+    WKChannelHistorySearchEmptyModeOffline,          // 离线
+};
+
+@interface WKChannelHistorySearchEmptyView : UIView
+
+@property (nonatomic, assign) WKChannelHistorySearchEmptyMode mode;
+@property (nonatomic, copy, nullable) NSString *primaryText;    // 主文案；nil 用 mode 默认值
+@property (nonatomic, copy, nullable) NSString *secondaryText;  // 副文案
+@property (nonatomic, copy, nullable) void(^onRetry)(void);     // 重试回调（仅 Error 模式显示按钮）
+
+- (void)applyMode:(WKChannelHistorySearchEmptyMode)mode
+       primary:(nullable NSString *)primary
+     secondary:(nullable NSString *)secondary;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistorySearchEmptyView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Cells/WKChannelHistorySearchEmptyView.m
@@ -1,0 +1,145 @@
+//
+//  WKChannelHistorySearchEmptyView.m
+//
+
+#import "WKChannelHistorySearchEmptyView.h"
+#import "WKApp.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+
+@interface WKChannelHistorySearchEmptyView ()
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) UIImageView *iconView;
+@property (nonatomic, strong) UILabel *primaryLbl;
+@property (nonatomic, strong) UILabel *secondaryLbl;
+@property (nonatomic, strong) UIButton *retryBtn;
+@end
+
+@implementation WKChannelHistorySearchEmptyView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [UIColor clearColor];
+        self.userInteractionEnabled = YES;
+
+        _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+        _spinner.hidesWhenStopped = YES;
+        _spinner.color = [WKApp shared].config.themeColor;
+        [self addSubview:_spinner];
+
+        _iconView = [UIImageView new];
+        _iconView.contentMode = UIViewContentModeScaleAspectFit;
+        _iconView.tintColor = [[UIColor grayColor] colorWithAlphaComponent:0.6];
+        [self addSubview:_iconView];
+
+        _primaryLbl = [UILabel new];
+        _primaryLbl.font = [[WKApp shared].config appFontOfSize:15.0f];
+        _primaryLbl.textColor = [UIColor grayColor];
+        _primaryLbl.textAlignment = NSTextAlignmentCenter;
+        _primaryLbl.numberOfLines = 0;
+        [self addSubview:_primaryLbl];
+
+        _secondaryLbl = [UILabel new];
+        _secondaryLbl.font = [[WKApp shared].config appFontOfSize:13.0f];
+        _secondaryLbl.textColor = [[UIColor grayColor] colorWithAlphaComponent:0.7];
+        _secondaryLbl.textAlignment = NSTextAlignmentCenter;
+        _secondaryLbl.numberOfLines = 0;
+        [self addSubview:_secondaryLbl];
+
+        _retryBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+        _retryBtn.titleLabel.font = [[WKApp shared].config appFontOfSize:14.0f];
+        [_retryBtn setTitleColor:[WKApp shared].config.themeColor forState:UIControlStateNormal];
+        [_retryBtn setTitle:LLang(@"点击重试") forState:UIControlStateNormal];
+        _retryBtn.layer.cornerRadius = 14.0f;
+        _retryBtn.layer.borderColor = [WKApp shared].config.themeColor.CGColor;
+        _retryBtn.layer.borderWidth = 1.0f;
+        _retryBtn.contentEdgeInsets = UIEdgeInsetsMake(6, 18, 6, 18);
+        _retryBtn.hidden = YES;
+        [_retryBtn addTarget:self action:@selector(onRetryTap) forControlEvents:UIControlEventTouchUpInside];
+        [self addSubview:_retryBtn];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat w = self.lim_width;
+    CGFloat h = self.lim_height;
+    // 整体居中，距顶部约 1/3
+    CGFloat centerY = h * 0.4f;
+    CGFloat textW = MIN(w - 60, 280);
+    CGFloat cursorY = centerY - 60.0f;
+
+    self.spinner.lim_centerX = w / 2.0f;
+    self.spinner.lim_centerY = cursorY;
+    self.iconView.frame = CGRectMake((w - 64) / 2.0f, cursorY - 32.0f, 64, 64);
+
+    if (!self.iconView.hidden) {
+        cursorY = CGRectGetMaxY(self.iconView.frame) + 14.0f;
+    } else if (self.spinner.isAnimating) {
+        cursorY = CGRectGetMaxY(self.spinner.frame) + 14.0f;
+    } else {
+        cursorY = centerY;
+    }
+
+    self.primaryLbl.frame = CGRectMake((w - textW) / 2.0f, cursorY, textW, 22.0f);
+    cursorY = CGRectGetMaxY(self.primaryLbl.frame) + 6.0f;
+    self.secondaryLbl.frame = CGRectMake((w - textW) / 2.0f, cursorY, textW, 18.0f);
+    if (self.secondaryLbl.text.length > 0) {
+        cursorY = CGRectGetMaxY(self.secondaryLbl.frame) + 14.0f;
+    }
+    [self.retryBtn sizeToFit];
+    CGFloat bw = MAX(96.0f, self.retryBtn.lim_width);
+    self.retryBtn.frame = CGRectMake((w - bw) / 2.0f, cursorY, bw, 30.0f);
+}
+
+- (void)onRetryTap {
+    if (self.onRetry) self.onRetry();
+}
+
+- (void)setMode:(WKChannelHistorySearchEmptyMode)mode {
+    [self applyMode:mode primary:nil secondary:nil];
+}
+
+- (void)applyMode:(WKChannelHistorySearchEmptyMode)mode
+       primary:(NSString *)primary
+     secondary:(NSString *)secondary {
+    _mode = mode;
+    self.spinner.hidden = (mode != WKChannelHistorySearchEmptyModeLoading);
+    if (mode == WKChannelHistorySearchEmptyModeLoading) {
+        [self.spinner startAnimating];
+    } else {
+        [self.spinner stopAnimating];
+    }
+    self.iconView.hidden = (mode == WKChannelHistorySearchEmptyModeLoading);
+    self.retryBtn.hidden = (mode != WKChannelHistorySearchEmptyModeError && mode != WKChannelHistorySearchEmptyModeOffline);
+    // 文案
+    NSString *p = primary;
+    NSString *s = secondary;
+    switch (mode) {
+        case WKChannelHistorySearchEmptyModeWaitingInput:
+            if (p.length == 0) p = LLang(@"输入关键词查找此聊天内的记录");
+            break;
+        case WKChannelHistorySearchEmptyModeNoResults:
+            if (p.length == 0) p = LLang(@"未找到相关内容");
+            if (s.length == 0) s = LLang(@"换个关键词或调整筛选条件再试试");
+            break;
+        case WKChannelHistorySearchEmptyModeLoading:
+            if (p.length == 0) p = LLang(@"搜索中…");
+            break;
+        case WKChannelHistorySearchEmptyModeError:
+            if (p.length == 0) p = LLang(@"加载失败");
+            if (s.length == 0) s = LLang(@"请检查网络后重试");
+            break;
+        case WKChannelHistorySearchEmptyModeOffline:
+            if (p.length == 0) p = LLang(@"当前网络不可用");
+            if (s.length == 0) s = LLang(@"请检查网络设置");
+            break;
+    }
+    self.primaryLbl.text = p;
+    self.secondaryLbl.text = s;
+    [self setNeedsLayout];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.h
@@ -1,0 +1,29 @@
+//
+//  WKChannelHistoryFilterVC.h
+//  WuKongBase
+//
+//  搜索页"筛选"半屏（modal）：发送人 / 日期 / 排序 + 底部重置/应用。
+//
+
+#import <UIKit/UIKit.h>
+#import "WKChannelHistorySearchModels.h"
+
+@class WKChannel;
+@class WKChannelHistoryFilterVC;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol WKChannelHistoryFilterVCDelegate <NSObject>
+- (void)channelHistoryFilterVC:(WKChannelHistoryFilterVC *)vc didApplyFilter:(WKChannelHistorySearchFilter *)filter;
+@end
+
+@interface WKChannelHistoryFilterVC : UIViewController
+
+@property (nonatomic, strong) WKChannel *channel;
+/// 当前筛选条件草稿（外部传入，本 VC 内部会复制一份编辑）。
+@property (nonatomic, strong) WKChannelHistorySearchFilter *draft;
+@property (nonatomic, weak, nullable) id<WKChannelHistoryFilterVCDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
@@ -238,9 +238,17 @@
                                                           preferredStyle:UIAlertControllerStyleActionSheet];
     void(^apply)(NSInteger) = ^(NSInteger days) {
         NSDate *end = [NSDate date];
-        NSDate *start = days > 0
-            ? [end dateByAddingTimeInterval:-(days * 24 * 3600)]
-            : nil;
+        NSDate *start;
+        if (days <= 0) {
+            start = nil;
+        } else if (days == 1) {
+            // "今天" 特化: 起点为今日 00:00, 不做 24h 回退。API 只发 yyyy-MM-dd (见
+            // WKChannelHistorySearchModels.toApiDict), now-24h 会拿到昨日日期使
+            // sent_at_from 跨两个自然日 (PR #64 review yujiawei 命中)。
+            start = [[NSCalendar currentCalendar] startOfDayForDate:end];
+        } else {
+            start = [end dateByAddingTimeInterval:-(days * 24 * 3600)];
+        }
         self.draft.startDate = start;
         self.draft.endDate = days > 0 ? end : nil;
         [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationNone];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
@@ -221,6 +221,14 @@
         [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationNone];
     }]];
     [ac addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    // iPad 上 actionSheet 走 popover, 必须有非 nil 的 sourceView + sourceRect。
+    // 起/止日期两个日期入口都是从 filter 表格里的日期 cell 点触发, 直接锚到 self.view 中心。
+    if (ac.popoverPresentationController) {
+        ac.popoverPresentationController.sourceView = self.view;
+        ac.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width / 2,
+                                                                 self.view.bounds.size.height / 2, 0, 0);
+        ac.popoverPresentationController.permittedArrowDirections = 0;
+    }
     [self presentViewController:ac animated:YES completion:nil];
 }
 
@@ -242,6 +250,12 @@
     [ac addAction:[UIAlertAction actionWithTitle:LLang(@"最近 30 天") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(30); }]];
     [ac addAction:[UIAlertAction actionWithTitle:LLang(@"全部时间") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(0); }]];
     [ac addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    if (ac.popoverPresentationController) {
+        ac.popoverPresentationController.sourceView = self.view;
+        ac.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width / 2,
+                                                                 self.view.bounds.size.height / 2, 0, 0);
+        ac.popoverPresentationController.permittedArrowDirections = 0;
+    }
     [self presentViewController:ac animated:YES completion:nil];
 }
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistoryFilterVC.m
@@ -1,0 +1,276 @@
+//
+//  WKChannelHistoryFilterVC.m
+//
+
+#import "WKChannelHistoryFilterVC.h"
+#import "WKChannelHistorySenderPickerVC.h"
+#import "WKApp.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+#import "WKGroupManager.h"
+
+#define kRowHeight 52.0f
+
+@interface WKChannelHistoryFilterVC () <
+    UITableViewDataSource, UITableViewDelegate,
+    WKChannelHistorySenderPickerVCDelegate
+>
+
+@property (nonatomic, strong) UITableView *tableView;
+@property (nonatomic, strong) UIView *bottomBar;
+@property (nonatomic, strong) UIButton *resetBtn;
+@property (nonatomic, strong) UIButton *applyBtn;
+
+/// 已加载的发送人简要展示文本缓存（避免每次 cellForRow 都查 channel manager）。
+@property (nonatomic, copy) NSString *senderSummaryText;
+
+@end
+
+@implementation WKChannelHistoryFilterVC
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.title = LLang(@"筛选");
+    if (!self.draft) self.draft = [WKChannelHistorySearchFilter new];
+
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                          target:self
+                                                                                          action:@selector(onCancel)];
+
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+    self.tableView.rowHeight = kRowHeight;
+    self.tableView.backgroundColor = [WKApp shared].config.backgroundColor;
+    [self.view addSubview:self.tableView];
+
+    self.bottomBar = [UIView new];
+    self.bottomBar.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+    [self.view addSubview:self.bottomBar];
+
+    self.resetBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.resetBtn setTitle:LLang(@"重置") forState:UIControlStateNormal];
+    [self.resetBtn setTitleColor:[UIColor darkGrayColor] forState:UIControlStateNormal];
+    self.resetBtn.titleLabel.font = [[WKApp shared].config appFontOfSize:16.0f];
+    self.resetBtn.layer.borderWidth = 0.5f;
+    self.resetBtn.layer.borderColor = [[UIColor grayColor] colorWithAlphaComponent:0.3].CGColor;
+    self.resetBtn.layer.cornerRadius = 22.0f;
+    [self.resetBtn addTarget:self action:@selector(onReset) forControlEvents:UIControlEventTouchUpInside];
+    [self.bottomBar addSubview:self.resetBtn];
+
+    self.applyBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.applyBtn setTitle:LLang(@"应用") forState:UIControlStateNormal];
+    [self.applyBtn setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    self.applyBtn.titleLabel.font = [[WKApp shared].config appFontOfSize:16.0f];
+    self.applyBtn.backgroundColor = [WKApp shared].config.themeColor;
+    self.applyBtn.layer.cornerRadius = 22.0f;
+    [self.applyBtn addTarget:self action:@selector(onApply) forControlEvents:UIControlEventTouchUpInside];
+    [self.bottomBar addSubview:self.applyBtn];
+
+    [self refreshSenderSummary];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CGFloat barH = 64.0f;
+    CGFloat safe = self.view.safeAreaInsets.bottom;
+    CGFloat barY = self.view.lim_height - safe - barH;
+    self.tableView.frame = CGRectMake(0, 0, self.view.lim_width, barY);
+    self.bottomBar.frame = CGRectMake(0, barY, self.view.lim_width, barH + safe);
+    CGFloat btnW = (self.view.lim_width - 16 * 3) / 2.0f;
+    self.resetBtn.frame = CGRectMake(16, 10, btnW, 44);
+    self.applyBtn.frame = CGRectMake(self.view.lim_width - 16 - btnW, 10, btnW, 44);
+}
+
+#pragma mark - sender summary
+
+- (void)refreshSenderSummary {
+    NSArray<NSString *> *uids = self.draft.senderUids ?: @[];
+    if (uids.count == 0) {
+        self.senderSummaryText = LLang(@"全部成员");
+        return;
+    }
+    // 简单显示数量；多人时不在此 fetch 头像名，避免拖慢
+    self.senderSummaryText = [NSString stringWithFormat:LLang(@"已选 %ld 人"), (long)uids.count];
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return 3; }
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (section == 0) return 1; // sender
+    if (section == 1) return 3; // start date / end date / preset
+    return 2; // sort: desc / asc
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    return 32.0f;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
+    UIView *v = [UIView new];
+    v.backgroundColor = [WKApp shared].config.backgroundColor;
+    UILabel *t = [UILabel new];
+    t.frame = CGRectMake(16, 8, 300, 22);
+    t.font = [[WKApp shared].config appFontOfSize:13.0f];
+    t.textColor = [UIColor grayColor];
+    if (section == 0) t.text = LLang(@"发送人");
+    else if (section == 1) t.text = LLang(@"日期范围");
+    else t.text = LLang(@"排序");
+    [v addSubview:t];
+    return v;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"row"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"row"];
+    }
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.accessoryType = UITableViewCellAccessoryNone;
+    cell.textLabel.font = [[WKApp shared].config appFontOfSize:15.0f];
+    cell.textLabel.textColor = [WKApp shared].config.defaultTextColor;
+    cell.detailTextLabel.font = [[WKApp shared].config appFontOfSize:14.0f];
+    cell.detailTextLabel.textColor = [UIColor grayColor];
+
+    static NSDateFormatter *dateFmt = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        dateFmt = [NSDateFormatter new];
+        dateFmt.dateFormat = @"yyyy/MM/dd";
+    });
+
+    if (indexPath.section == 0) {
+        cell.textLabel.text = LLang(@"选择发送人");
+        cell.detailTextLabel.text = self.senderSummaryText;
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    } else if (indexPath.section == 1) {
+        if (indexPath.row == 0) {
+            cell.textLabel.text = LLang(@"起始日期");
+            cell.detailTextLabel.text = self.draft.startDate ? [dateFmt stringFromDate:self.draft.startDate] : LLang(@"不限");
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        } else if (indexPath.row == 1) {
+            cell.textLabel.text = LLang(@"结束日期");
+            cell.detailTextLabel.text = self.draft.endDate ? [dateFmt stringFromDate:self.draft.endDate] : LLang(@"不限");
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        } else {
+            cell.textLabel.text = LLang(@"快速选择");
+            cell.detailTextLabel.text = LLang(@"今天 / 7 天 / 30 天 / 全部");
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        }
+    } else {
+        NSInteger curSort = self.draft.sort;
+        BOOL selected = (indexPath.row == 0 && curSort == WKChannelHistorySearchSortTimeDesc)
+                      || (indexPath.row == 1 && curSort == WKChannelHistorySearchSortTimeAsc);
+        cell.textLabel.text = indexPath.row == 0 ? LLang(@"时间倒序（最新在前）") : LLang(@"时间正序（最早在前）");
+        cell.detailTextLabel.text = selected ? @"✓" : @"";
+        cell.detailTextLabel.textColor = [WKApp shared].config.themeColor;
+    }
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section == 0) {
+        WKChannelHistorySenderPickerVC *p = [WKChannelHistorySenderPickerVC new];
+        p.channel = self.channel;
+        p.selectedUids = self.draft.senderUids ?: @[];
+        p.delegate = self;
+        [self.navigationController pushViewController:p animated:YES];
+    } else if (indexPath.section == 1) {
+        if (indexPath.row == 0) [self showDatePickerForStart:YES];
+        else if (indexPath.row == 1) [self showDatePickerForStart:NO];
+        else [self showPresetSheet];
+    } else {
+        self.draft.sort = (indexPath.row == 0)
+            ? WKChannelHistorySearchSortTimeDesc
+            : WKChannelHistorySearchSortTimeAsc;
+        [tableView reloadSections:[NSIndexSet indexSetWithIndex:2] withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+#pragma mark - date
+
+- (void)showDatePickerForStart:(BOOL)isStart {
+    UIAlertController *ac = [UIAlertController alertControllerWithTitle:isStart ? LLang(@"起始日期") : LLang(@"结束日期")
+                                                                 message:@"\n\n\n\n\n\n\n\n\n"
+                                                          preferredStyle:UIAlertControllerStyleActionSheet];
+    UIDatePicker *picker = [[UIDatePicker alloc] initWithFrame:CGRectMake(0, 30, ac.view.lim_width - 20, 200)];
+    picker.datePickerMode = UIDatePickerModeDate;
+    if (@available(iOS 14.0, *)) picker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+    NSDate *initial = isStart ? self.draft.startDate : self.draft.endDate;
+    if (!initial) initial = [NSDate date];
+    picker.date = initial;
+    [ac.view addSubview:picker];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"清除") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *a) {
+        if (isStart) self.draft.startDate = nil; else self.draft.endDate = nil;
+        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationNone];
+    }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"确定") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        if (isStart) self.draft.startDate = picker.date; else self.draft.endDate = picker.date;
+        // 守卫：开始 > 结束 时自动交换，避免请求体两个日期顺序倒挂导致服务端返回空。
+        if (self.draft.startDate && self.draft.endDate
+            && [self.draft.startDate compare:self.draft.endDate] == NSOrderedDescending) {
+            NSDate *tmp = self.draft.startDate;
+            self.draft.startDate = self.draft.endDate;
+            self.draft.endDate = tmp;
+        }
+        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationNone];
+    }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:ac animated:YES completion:nil];
+}
+
+- (void)showPresetSheet {
+    UIAlertController *ac = [UIAlertController alertControllerWithTitle:LLang(@"快速选择")
+                                                                 message:nil
+                                                          preferredStyle:UIAlertControllerStyleActionSheet];
+    void(^apply)(NSInteger) = ^(NSInteger days) {
+        NSDate *end = [NSDate date];
+        NSDate *start = days > 0
+            ? [end dateByAddingTimeInterval:-(days * 24 * 3600)]
+            : nil;
+        self.draft.startDate = start;
+        self.draft.endDate = days > 0 ? end : nil;
+        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationNone];
+    };
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"今天") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(1); }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"最近 7 天") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(7); }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"最近 30 天") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(30); }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"全部时间") style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) { apply(0); }]];
+    [ac addAction:[UIAlertAction actionWithTitle:LLang(@"取消") style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:ac animated:YES completion:nil];
+}
+
+#pragma mark - sender picker delegate
+
+- (void)senderPickerVC:(WKChannelHistorySenderPickerVC *)vc didFinishWithUids:(NSArray<NSString *> *)uids {
+    self.draft.senderUids = uids;
+    [self refreshSenderSummary];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+#pragma mark - bottom
+
+- (void)onReset {
+    self.draft = [WKChannelHistorySearchFilter new];
+    [self refreshSenderSummary];
+    [self.tableView reloadData];
+}
+
+- (void)onApply {
+    if ([self.delegate respondsToSelector:@selector(channelHistoryFilterVC:didApplyFilter:)]) {
+        [self.delegate channelHistoryFilterVC:self didApplyFilter:self.draft];
+    } else {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+}
+
+- (void)onCancel {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.h
@@ -1,0 +1,34 @@
+//
+//  WKChannelHistorySenderPickerVC.h
+//  WuKongBase
+//
+//  发送人选择子页：群/子区拉成员（子区使用父群），私聊本地合成 [自己,对方]。
+//
+
+#import <UIKit/UIKit.h>
+
+@class WKChannel;
+@class WKChannelHistorySenderPickerVC;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// 发送人简化模型。
+@interface WKChannelHistorySenderEntry : NSObject
+@property (nonatomic, copy) NSString *uid;
+@property (nonatomic, copy) NSString *displayName;
+@property (nonatomic, copy, nullable) NSString *avatarUrl;
+@end
+
+@protocol WKChannelHistorySenderPickerVCDelegate <NSObject>
+- (void)senderPickerVC:(WKChannelHistorySenderPickerVC *)vc didFinishWithUids:(NSArray<NSString *> *)uids;
+@end
+
+@interface WKChannelHistorySenderPickerVC : UIViewController
+
+@property (nonatomic, strong) WKChannel *channel;
+@property (nonatomic, copy) NSArray<NSString *> *selectedUids;
+@property (nonatomic, weak, nullable) id<WKChannelHistorySenderPickerVCDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
@@ -81,6 +81,10 @@
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NSMutableArray<WKChannelHistorySenderEntry *> *entries;
 @property (nonatomic, strong) NSMutableSet<NSString *> *selected;
+// 搜索请求单调计数器: 快速打字时 searchMembers: 是异步的, 慢完成的老 keyword
+// 结果不能覆盖新 keyword 已经清空的 entries (PR #64 review 3 位 reviewer 独立命中)。
+// 与 WKChannelHistorySearchVM.reqIdCounter 同款模式。
+@property (nonatomic, assign) NSInteger reqIdCounter;
 @end
 
 @implementation WKChannelHistorySenderPickerVC
@@ -136,6 +140,8 @@
 
 - (void)loadEntriesWithKeyword:(nullable NSString *)keyword {
     [self.entries removeAllObjects];
+    self.reqIdCounter += 1;
+    NSInteger reqId = self.reqIdCounter;
     if (self.channel.channelType == WK_PERSON) {
         // 自己 + 对方
         NSString *myUid = [WKSDK shared].options.connectInfo.uid;
@@ -170,20 +176,25 @@
             lookupChannel = [[WKChannel alloc] initWith:groupNo channelType:WK_GROUP];
         }
     }
+    __weak typeof(self) ws = self;
     [WKGroupManager.shared searchMembers:lookupChannel
                                   keyword:keyword ?: @""
                                      page:1
                                     limit:200
                           requestStrategy:WKRequestStrategyOnlyNetwork
                                  complete:^(WKChannelMemberCacheType cacheType, NSArray<WKChannelMember *> * _Nonnull members) {
+        __strong typeof(ws) ss = ws;
+        if (!ss) return;
+        // 只有 reqId 仍是最新一轮的才 append; 慢完成的老 keyword 结果直接丢弃。
+        if (reqId != ss.reqIdCounter) return;
         for (WKChannelMember *m in members) {
             WKChannelHistorySenderEntry *e = [WKChannelHistorySenderEntry new];
             e.uid = m.memberUid ?: @"";
             e.displayName = m.memberName.length > 0 ? m.memberName : (m.memberRemark.length > 0 ? m.memberRemark : m.memberUid);
             e.avatarUrl = nil;
-            if (e.uid.length > 0) [self.entries addObject:e];
+            if (e.uid.length > 0) [ss.entries addObject:e];
         }
-        [self.tableView reloadData];
+        [ss.tableView reloadData];
     }];
 }
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
@@ -1,0 +1,229 @@
+//
+//  WKChannelHistorySenderPickerVC.m
+//
+
+#import "WKChannelHistorySenderPickerVC.h"
+#import "WKApp.h"
+#import "UIView+WKCommon.h"
+#import "WuKongBase.h"
+#import "WKAvatarUtil.h"
+#import "WKUserAvatar.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+#import "WKGroupManager.h"
+
+@implementation WKChannelHistorySenderEntry
+@end
+
+#pragma mark - Cell
+
+@interface WKChannelHistorySenderCell : UITableViewCell
+@property (nonatomic, strong) WKUserAvatar *avatarView;
+@property (nonatomic, strong) UILabel *nameLbl;
+@property (nonatomic, strong) UIImageView *checkView;
+@end
+
+@implementation WKChannelHistorySenderCell
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+        _avatarView = [[WKUserAvatar alloc] initWithFrame:CGRectMake(16, 8, 36, 36)];
+        [self.contentView addSubview:_avatarView];
+        _nameLbl = [UILabel new];
+        _nameLbl.font = [[WKApp shared].config appFontOfSize:15.0f];
+        _nameLbl.textColor = [WKApp shared].config.defaultTextColor;
+        [self.contentView addSubview:_nameLbl];
+        _checkView = [[UIImageView alloc] init];
+        _checkView.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.1];
+        _checkView.layer.cornerRadius = 10.0f;
+        _checkView.layer.masksToBounds = YES;
+        _checkView.contentMode = UIViewContentModeCenter;
+        [self.contentView addSubview:_checkView];
+    }
+    return self;
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat w = self.contentView.lim_width;
+    self.avatarView.frame = CGRectMake(16, (52 - 36) / 2.0f, 36, 36);
+    self.checkView.frame = CGRectMake(w - 16 - 20, (52 - 20) / 2.0f, 20, 20);
+    self.nameLbl.frame = CGRectMake(CGRectGetMaxX(self.avatarView.frame) + 12, 0, w - 16 - 20 - 12 - CGRectGetMaxX(self.avatarView.frame) - 8, 52);
+}
+- (void)applyEntry:(WKChannelHistorySenderEntry *)e selected:(BOOL)selected {
+    self.nameLbl.text = e.displayName ?: @"";
+    NSString *url = e.avatarUrl.length > 0
+        ? [WKAvatarUtil getFullAvatarWIthPath:e.avatarUrl]
+        : [WKAvatarUtil getAvatar:e.uid];
+    self.avatarView.url = url;
+    self.checkView.backgroundColor = selected
+        ? [WKApp shared].config.themeColor
+        : [[UIColor grayColor] colorWithAlphaComponent:0.1];
+    self.checkView.tintColor = [UIColor whiteColor];
+    // 选中用一个"✓"字符标识，避免依赖图片资源
+    for (UIView *sub in [self.checkView.subviews copy]) [sub removeFromSuperview];
+    if (selected) {
+        UILabel *t = [UILabel new];
+        t.text = @"✓";
+        t.textAlignment = NSTextAlignmentCenter;
+        t.textColor = [UIColor whiteColor];
+        t.font = [UIFont systemFontOfSize:13.0f weight:UIFontWeightBold];
+        t.frame = self.checkView.bounds;
+        [self.checkView addSubview:t];
+    }
+}
+@end
+
+#pragma mark - VC
+
+@interface WKChannelHistorySenderPickerVC () <UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate>
+@property (nonatomic, strong) UISearchBar *searchBar;
+@property (nonatomic, strong) UITableView *tableView;
+@property (nonatomic, strong) NSMutableArray<WKChannelHistorySenderEntry *> *entries;
+@property (nonatomic, strong) NSMutableSet<NSString *> *selected;
+@end
+
+@implementation WKChannelHistorySenderPickerVC
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.title = LLang(@"选择发送人");
+    self.entries = [NSMutableArray array];
+    self.selected = [NSMutableSet setWithArray:self.selectedUids ?: @[]];
+
+    UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithTitle:LLang(@"完成")
+                                                              style:UIBarButtonItemStyleDone
+                                                             target:self
+                                                             action:@selector(onDone)];
+    self.navigationItem.rightBarButtonItem = done;
+
+    self.searchBar = [[UISearchBar alloc] init];
+    self.searchBar.placeholder = LLang(@"搜索成员");
+    self.searchBar.delegate = self;
+    self.searchBar.backgroundImage = [UIImage new];
+    [self.view addSubview:self.searchBar];
+
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+    self.tableView.rowHeight = 52.0f;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    self.tableView.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    [self.tableView registerClass:WKChannelHistorySenderCell.class forCellReuseIdentifier:@"sender"];
+    [self.view addSubview:self.tableView];
+
+    [self loadEntriesWithKeyword:nil];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CGFloat top = self.navigationController.navigationBar.lim_bottom;
+    if (top == 0) top = 44 + (self.view.window.windowScene.statusBarManager.statusBarFrame.size.height ?: 20);
+    self.searchBar.frame = CGRectMake(0, top, self.view.lim_width, 44);
+    self.tableView.frame = CGRectMake(0, self.searchBar.lim_bottom, self.view.lim_width, self.view.lim_height - self.searchBar.lim_bottom);
+}
+
+- (void)onDone {
+    if ([self.delegate respondsToSelector:@selector(senderPickerVC:didFinishWithUids:)]) {
+        [self.delegate senderPickerVC:self didFinishWithUids:[self.selected.allObjects copy]];
+    }
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
+#pragma mark - load
+
+- (void)loadEntriesWithKeyword:(nullable NSString *)keyword {
+    [self.entries removeAllObjects];
+    if (self.channel.channelType == WK_PERSON) {
+        // 自己 + 对方
+        NSString *myUid = [WKSDK shared].options.connectInfo.uid;
+        WKChannelInfo *peer = [[WKSDK shared].channelManager getChannelInfo:self.channel];
+        WKChannelHistorySenderEntry *me = [WKChannelHistorySenderEntry new];
+        me.uid = myUid ?: @"";
+        me.displayName = LLang(@"我");
+        if (me.uid.length > 0) [self.entries addObject:me];
+
+        WKChannelHistorySenderEntry *p = [WKChannelHistorySenderEntry new];
+        p.uid = self.channel.channelId ?: @"";
+        p.displayName = peer ? (peer.remark.length > 0 ? peer.remark : peer.name) : self.channel.channelId;
+        p.avatarUrl = peer.logo;
+        if (p.uid.length > 0) [self.entries addObject:p];
+
+        if (keyword.length > 0) {
+            NSPredicate *pred = [NSPredicate predicateWithBlock:^BOOL(WKChannelHistorySenderEntry *e, id b) {
+                return [e.displayName.lowercaseString containsString:keyword.lowercaseString];
+            }];
+            [self.entries filterUsingPredicate:pred];
+        }
+        [self.tableView reloadData];
+        return;
+    }
+
+    // 群 / 子区：用 WKGroupManager.searchMembers (子区使用父群)
+    WKChannel *lookupChannel = self.channel;
+    if (self.channel.channelType == WK_COMMUNITY_TOPIC) {
+        NSRange r = [self.channel.channelId rangeOfString:@"____"];
+        if (r.location != NSNotFound) {
+            NSString *groupNo = [self.channel.channelId substringToIndex:r.location];
+            lookupChannel = [[WKChannel alloc] initWith:groupNo channelType:WK_GROUP];
+        }
+    }
+    [WKGroupManager.shared searchMembers:lookupChannel
+                                  keyword:keyword ?: @""
+                                     page:1
+                                    limit:200
+                          requestStrategy:WKRequestStrategyOnlyNetwork
+                                 complete:^(WKChannelMemberCacheType cacheType, NSArray<WKChannelMember *> * _Nonnull members) {
+        for (WKChannelMember *m in members) {
+            WKChannelHistorySenderEntry *e = [WKChannelHistorySenderEntry new];
+            e.uid = m.memberUid ?: @"";
+            e.displayName = m.memberName.length > 0 ? m.memberName : (m.memberRemark.length > 0 ? m.memberRemark : m.memberUid);
+            e.avatarUrl = nil;
+            if (e.uid.length > 0) [self.entries addObject:e];
+        }
+        [self.tableView reloadData];
+    }];
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.entries.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    WKChannelHistorySenderCell *c = [tableView dequeueReusableCellWithIdentifier:@"sender" forIndexPath:indexPath];
+    WKChannelHistorySenderEntry *e = self.entries[indexPath.row];
+    [c applyEntry:e selected:[self.selected containsObject:e.uid]];
+    return c;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    WKChannelHistorySenderEntry *e = self.entries[indexPath.row];
+    if ([self.selected containsObject:e.uid]) {
+        [self.selected removeObject:e.uid];
+    } else {
+        if (self.selected.count >= 50) {
+            [self.view showMsg:LLang(@"最多选择 50 人")];
+            return;
+        }
+        [self.selected addObject:e.uid];
+    }
+    [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+#pragma mark - UISearchBar
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(reloadByKeyword:) object:nil];
+    [self performSelector:@selector(reloadByKeyword:) withObject:searchText afterDelay:0.16];
+}
+
+- (void)reloadByKeyword:(NSString *)kw {
+    [self loadEntriesWithKeyword:kw];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Filter/WKChannelHistorySenderPickerVC.m
@@ -237,4 +237,11 @@
     [self loadEntriesWithKeyword:kw];
 }
 
+- (void)dealloc {
+    // performSelector:afterDelay: 会强引用 self 直到 selector 触发, 用户在
+    // 0.16s 打字 debounce 窗口内快速 pop VC 时, pending 调度会撞到 dealloc-ing
+    // self 上 (PR #64 review Octo-Q P2)。dealloc 里主动清一次, 无副作用。
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(reloadByKeyword:) object:nil];
+}
+
 @end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.h
@@ -1,0 +1,29 @@
+//
+//  WKChannelHistoryFileDownloader.h
+//  WuKongBase
+//
+//  把搜索结果的远端文件下载到 temp 目录, 命名按真实文件名 (避免 QLPreview 标题显示
+//  16 进制), 拿到本地路径后回调。同一 URL 命中已下载缓存则直接复用, 不重复拉。
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// 进度 0..1。完成时 error == nil 且 localURL 有值; 失败时 error 非空。
+typedef void(^WKChannelHistoryFileDownloadHandler)(NSURL * _Nullable localURL, NSError * _Nullable error);
+typedef void(^WKChannelHistoryFileProgressHandler)(double progress);
+
+@interface WKChannelHistoryFileDownloader : NSObject
+
+/// 下载 remoteUrl 到 temp/WKChannelHistoryFile/<realName>。
+/// 同一 (remoteUrl, fileName) 命中缓存时直接 completion(localURL, nil)。
+/// 返回的 task 可用于取消。
++ (NSURLSessionDownloadTask * _Nullable)downloadRemoteUrl:(NSString *)remoteUrl
+                                                  fileName:(nullable NSString *)fileName
+                                                   onProgress:(nullable WKChannelHistoryFileProgressHandler)onProgress
+                                                onComplete:(WKChannelHistoryFileDownloadHandler)onComplete;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.h
@@ -16,6 +16,12 @@ typedef void(^WKChannelHistoryFileProgressHandler)(double progress);
 
 @interface WKChannelHistoryFileDownloader : NSObject
 
+/// 返回该 (remoteUrl, fileName) 组合在 tmp 缓存里的**目标路径** (不判断文件是否存在,
+/// 调用方需要自己 fileExists 检查)。用于流式视频 cell 判断"是否已经下过, 能否直接用
+/// file:// 起播代替 https 边下边播"。
++ (nullable NSString *)cachedLocalPathForRemoteUrl:(NSString *)remoteUrl
+                                            fileName:(nullable NSString *)fileName;
+
 /// 下载 remoteUrl 到 temp/WKChannelHistoryFile/<realName>。
 /// 同一 (remoteUrl, fileName) 命中缓存时直接 completion(localURL, nil)。
 /// 返回的 task 可用于取消。

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
@@ -3,6 +3,7 @@
 //
 
 #import "WKChannelHistoryFileDownloader.h"
+#import "WKApp.h"
 
 @interface WKChannelHistoryFileDownloader () <NSURLSessionDownloadDelegate>
 @property (nonatomic, copy) WKChannelHistoryFileDownloadHandler onComplete;
@@ -53,7 +54,10 @@
         }
         return nil;
     }
-    NSURL *url = [NSURL URLWithString:remoteUrl];
+    NSURL *url = [[WKApp shared] getFileFullUrl:remoteUrl];
+    // getFileFullUrl: 对 http(s) 起头的直接放行, 其它按 apiBaseUrl 拼接; 老实现只 URLWithString
+    // 相对路径回 nil, 服务端在个别 envelope 里下发相对 file/preview/... URL 就下载失败
+    // (PR #64 review yujiawei 命中, 与 WKChannelHistoryMediaBrowser 同源修复)。
     if (!url) {
         onComplete(nil, [NSError errorWithDomain:@"WKChannelHistoryFileDownloader"
                                             code:-2

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
@@ -1,0 +1,130 @@
+//
+//  WKChannelHistoryFileDownloader.m
+//
+
+#import "WKChannelHistoryFileDownloader.h"
+
+@interface WKChannelHistoryFileDownloader () <NSURLSessionDownloadDelegate>
+@property (nonatomic, copy) WKChannelHistoryFileDownloadHandler onComplete;
+@property (nonatomic, copy, nullable) WKChannelHistoryFileProgressHandler onProgress;
+@property (nonatomic, copy, nullable) NSString *destPath;
+@end
+
+@implementation WKChannelHistoryFileDownloader
+
++ (NSString *)cacheDir {
+    NSString *dir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"WKChannelHistoryFile"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    return dir;
+}
+
++ (NSString *)safeFileNameFromUrl:(NSString *)remoteUrl fileName:(NSString *)fileName {
+    NSString *name = [fileName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (name.length == 0) {
+        NSURL *u = [NSURL URLWithString:remoteUrl];
+        name = u.lastPathComponent;
+    }
+    if (name.length == 0) name = @"download";
+    // 过滤路径分隔符
+    name = [name stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+    name = [name stringByReplacingOccurrencesOfString:@"\\" withString:@"_"];
+    return name;
+}
+
++ (NSURLSessionDownloadTask *)downloadRemoteUrl:(NSString *)remoteUrl
+                                        fileName:(NSString *)fileName
+                                         onProgress:(WKChannelHistoryFileProgressHandler)onProgress
+                                      onComplete:(WKChannelHistoryFileDownloadHandler)onComplete {
+    if (remoteUrl.length == 0 || !onComplete) {
+        if (onComplete) {
+            onComplete(nil, [NSError errorWithDomain:@"WKChannelHistoryFileDownloader"
+                                                code:-1
+                                            userInfo:@{ NSLocalizedDescriptionKey: @"empty url" }]);
+        }
+        return nil;
+    }
+    NSURL *url = [NSURL URLWithString:remoteUrl];
+    if (!url) {
+        onComplete(nil, [NSError errorWithDomain:@"WKChannelHistoryFileDownloader"
+                                            code:-2
+                                        userInfo:@{ NSLocalizedDescriptionKey: @"invalid url" }]);
+        return nil;
+    }
+
+    NSString *safeName = [self safeFileNameFromUrl:remoteUrl fileName:fileName];
+    NSString *destPath = [[self cacheDir] stringByAppendingPathComponent:safeName];
+
+    // 缓存命中: 文件存在且非空 → 直接回调本地路径, 不重复下载。
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSDictionary *attrs = [fm attributesOfItemAtPath:destPath error:nil];
+    if (attrs && [attrs[NSFileSize] unsignedLongLongValue] > 0) {
+        onComplete([NSURL fileURLWithPath:destPath], nil);
+        return nil;
+    }
+
+    WKChannelHistoryFileDownloader *holder = [WKChannelHistoryFileDownloader new];
+    holder.onComplete = onComplete;
+    holder.onProgress = onProgress;
+    holder.destPath = destPath;
+
+    NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration defaultSessionConfiguration];
+    cfg.timeoutIntervalForRequest = 30;
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:cfg
+                                                          delegate:holder
+                                                     delegateQueue:[NSOperationQueue mainQueue]];
+    NSURLSessionDownloadTask *task = [session downloadTaskWithURL:url];
+    // 借助 task.priorityRetained 保活 holder — task 持有 session, session 持有 delegate(holder)。
+    [task resume];
+    return task;
+}
+
+#pragma mark - NSURLSessionDownloadDelegate
+
+- (void)URLSession:(NSURLSession *)session
+      downloadTask:(NSURLSessionDownloadTask *)downloadTask
+      didWriteData:(int64_t)bytesWritten
+ totalBytesWritten:(int64_t)totalBytesWritten
+totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+    if (self.onProgress && totalBytesExpectedToWrite > 0) {
+        double p = (double)totalBytesWritten / (double)totalBytesExpectedToWrite;
+        self.onProgress(p);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+      downloadTask:(NSURLSessionDownloadTask *)downloadTask
+didFinishDownloadingToURL:(NSURL *)location {
+    NSError *moveErr = nil;
+    NSFileManager *fm = [NSFileManager defaultManager];
+    // 移动到目标路径前先确保父目录存在 & 旧文件被替换。
+    NSString *dir = [self.destPath stringByDeletingLastPathComponent];
+    [fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    [fm removeItemAtPath:self.destPath error:nil];
+    BOOL ok = [fm moveItemAtURL:location toURL:[NSURL fileURLWithPath:self.destPath] error:&moveErr];
+    if (!ok) {
+        if (self.onComplete) self.onComplete(nil, moveErr ?: [NSError errorWithDomain:@"WKChannelHistoryFileDownloader" code:-3 userInfo:nil]);
+        return;
+    }
+    if (self.onComplete) self.onComplete([NSURL fileURLWithPath:self.destPath], nil);
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didCompleteWithError:(NSError *)error {
+    if (error && self.onComplete) {
+        // didFinishDownloadingToURL 没回包就先到 didCompleteWithError, 此时算失败。
+        // 成功路径里 didFinishDownloadingToURL 已经清掉了 onComplete? — 没有, 我们没清。
+        // 这里用一次性 guard: destPath 有文件视为成功路径已先回调。
+        NSFileManager *fm = [NSFileManager defaultManager];
+        if (![fm fileExistsAtPath:self.destPath]) {
+            self.onComplete(nil, error);
+            self.onComplete = nil;
+        }
+    }
+    [session finishTasksAndInvalidate];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
@@ -4,6 +4,7 @@
 
 #import "WKChannelHistoryFileDownloader.h"
 #import "WKApp.h"
+#import "WKMD5Util.h"
 
 @interface WKChannelHistoryFileDownloader () <NSURLSessionDownloadDelegate>
 @property (nonatomic, copy) WKChannelHistoryFileDownloadHandler onComplete;
@@ -35,11 +36,22 @@
     return name;
 }
 
+// PR #64 review yujiawei P1: 老实现 cache 路径只用 sanitized fileName, 两条
+// 不同 URL 但同名的消息 (chat 里 IMG_001.jpg / 报告.pdf 极常见) 会 collide,
+// 后到者拿到前者内容 — silent data corruption。用 URL 的 MD5 前 16 字符做
+// 子目录, 保留 fileName 作为叶子, 让用户下载出去看到的名字仍然是原名。
++ (NSString *)urlHashDirForRemoteUrl:(NSString *)remoteUrl {
+    if (remoteUrl.length == 0) return @"_nohash";
+    NSString *md5 = [WKMD5Util md5HexDigest:remoteUrl];
+    return md5.length >= 16 ? [md5 substringToIndex:16] : md5;
+}
+
 + (NSString *)cachedLocalPathForRemoteUrl:(NSString *)remoteUrl
                                     fileName:(NSString *)fileName {
     if (remoteUrl.length == 0) return nil;
+    NSString *hashDir = [self urlHashDirForRemoteUrl:remoteUrl];
     NSString *safe = [self safeFileNameFromUrl:remoteUrl fileName:fileName];
-    return [[self cacheDir] stringByAppendingPathComponent:safe];
+    return [[[self cacheDir] stringByAppendingPathComponent:hashDir] stringByAppendingPathComponent:safe];
 }
 
 + (NSURLSessionDownloadTask *)downloadRemoteUrl:(NSString *)remoteUrl
@@ -65,8 +77,10 @@
         return nil;
     }
 
-    NSString *safeName = [self safeFileNameFromUrl:remoteUrl fileName:fileName];
-    NSString *destPath = [[self cacheDir] stringByAppendingPathComponent:safeName];
+    // 下载目标路径必须与 cachedLocalPathForRemoteUrl: 保持完全一致
+    // (URL 哈希作子目录 + safeName 作叶子), 否则同名不同 URL 的 cache-hit
+    // 判定会跟真实产物错位 (PR #64 review yujiawei P1)。
+    NSString *destPath = [self cachedLocalPathForRemoteUrl:remoteUrl fileName:fileName];
 
     // 缓存命中: 文件存在且非空 → 直接回调本地路径, 不重复下载。
     NSFileManager *fm = [NSFileManager defaultManager];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFileDownloader.m
@@ -34,6 +34,13 @@
     return name;
 }
 
++ (NSString *)cachedLocalPathForRemoteUrl:(NSString *)remoteUrl
+                                    fileName:(NSString *)fileName {
+    if (remoteUrl.length == 0) return nil;
+    NSString *safe = [self safeFileNameFromUrl:remoteUrl fileName:fileName];
+    return [[self cacheDir] stringByAppendingPathComponent:safe];
+}
+
 + (NSURLSessionDownloadTask *)downloadRemoteUrl:(NSString *)remoteUrl
                                         fileName:(NSString *)fileName
                                          onProgress:(WKChannelHistoryFileProgressHandler)onProgress

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.h
@@ -1,0 +1,23 @@
+//
+//  WKChannelHistoryFilePreviewVC.h
+//  WuKongBase
+//
+//  搜索"文件"tab 的文件预览页 —— 子类化 WKSafeFilePreviewVC, 把右上角"分享"按钮
+//  替换为 "..." 菜单 (定位到聊天位置 / 保存文件)。
+//
+
+#import "WKSafeFilePreviewVC.h"
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryFilePreviewVC : WKSafeFilePreviewVC
+
+/// 搜索命中项, 用于「定位到聊天位置」回调上下文。
+@property (nonatomic, strong, nullable) WKChannelHistorySearchItem *historyItem;
+/// 「定位到聊天位置」回调 (item.canLocate == NO 时菜单项隐藏)。
+@property (nonatomic, copy, nullable) void(^onLocate)(WKChannelHistorySearchItem *item);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.m
@@ -1,0 +1,87 @@
+//
+//  WKChannelHistoryFilePreviewVC.m
+//
+
+#import "WKChannelHistoryFilePreviewVC.h"
+#import "WKApp.h"
+#import "WuKongBase.h"
+#import "UIView+WKCommon.h"
+#import "WKActionSheetView2.h"
+#import "WKActionSheetItem2.h"
+#import "WKNavigationManager.h"
+
+@interface WKChannelHistoryFilePreviewVC () <UIDocumentPickerDelegate>
+@end
+
+@implementation WKChannelHistoryFilePreviewVC
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // 父类 viewDidLoad 已经把分享按钮装到 rightView 上, 这里覆盖换成"..."。
+    UIButton *more = [UIButton buttonWithType:UIButtonTypeSystem];
+    more.frame = CGRectMake(0, 0, 44, 44);
+    UIImage *img = [WKApp.shared loadImage:@"Common/Index/More" moduleID:@"WuKongBase"];
+    if (img) {
+        [more setImage:[img imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+              forState:UIControlStateNormal];
+        more.tintColor = [WKApp shared].config.navBarButtonColor;
+    } else {
+        [more setTitle:@"⋯" forState:UIControlStateNormal];
+        [more setTitleColor:[WKApp shared].config.navBarButtonColor forState:UIControlStateNormal];
+        more.titleLabel.font = [UIFont systemFontOfSize:22 weight:UIFontWeightBold];
+    }
+    [more addTarget:self action:@selector(onMoreTap) forControlEvents:UIControlEventTouchUpInside];
+    self.navigationBar.rightView = more;
+}
+
+- (void)onMoreTap {
+    __weak typeof(self) ws = self;
+    WKActionSheetView2 *sheet = [WKActionSheetView2 initWithTip:nil];
+    if (self.historyItem.canLocate && self.onLocate) {
+        [sheet addItem:[WKActionSheetButtonItem2 initWithTitle:LLang(@"定位到聊天位置") onClick:^{
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            // 先关掉预览, 再跳聊天 — 让用户从 chat 返回直接回到搜索结果, 而不是回到这一层预览。
+            if (ss.navigationController.viewControllers.count > 1) {
+                [ss.navigationController popViewControllerAnimated:NO];
+            } else {
+                [ss dismissViewControllerAnimated:NO completion:nil];
+            }
+            if (ss.onLocate) ss.onLocate(ss.historyItem);
+        }]];
+    }
+    [sheet addItem:[WKActionSheetButtonItem2 initWithTitle:LLang(@"保存文件") onClick:^{
+        [ws presentSavePicker];
+    }]];
+    [sheet show];
+}
+
+- (void)presentSavePicker {
+    if (!self.fileURL) {
+        [self.view showMsg:LLang(@"文件不可用")];
+        return;
+    }
+    if (@available(iOS 14.0, *)) {
+        UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc]
+            initForExportingURLs:@[self.fileURL]];
+        picker.delegate = self;
+        [self presentViewController:picker animated:YES completion:nil];
+    } else {
+        // 兜底: 旧 iOS 用分享面板, 用户从分享列表里选「存储到文件」
+        UIActivityViewController *avc = [[UIActivityViewController alloc] initWithActivityItems:@[self.fileURL]
+                                                                          applicationActivities:nil];
+        [self presentViewController:avc animated:YES completion:nil];
+    }
+}
+
+#pragma mark - UIDocumentPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+    [self.view showMsg:LLang(@"已保存")];
+}
+
+- (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller {
+    // no-op
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryFilePreviewVC.m
@@ -70,6 +70,14 @@
         // 兜底: 旧 iOS 用分享面板, 用户从分享列表里选「存储到文件」
         UIActivityViewController *avc = [[UIActivityViewController alloc] initWithActivityItems:@[self.fileURL]
                                                                           applicationActivities:nil];
+        // iPad 上 UIActivityViewController 走 popover, 必须设置 sourceView (+ sourceRect)
+        // 或 barButtonItem, 否则抛 NSGenericException。这里没有明确的锚点按钮, 兜底到 self.view 中心。
+        if (avc.popoverPresentationController) {
+            avc.popoverPresentationController.sourceView = self.view;
+            avc.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width / 2,
+                                                                      self.view.bounds.size.height / 2, 0, 0);
+            avc.popoverPresentationController.permittedArrowDirections = 0;
+        }
         [self presentViewController:avc animated:YES completion:nil];
     }
 }

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.h
@@ -1,0 +1,32 @@
+//
+//  WKChannelHistoryMediaBrowser.h
+//  WuKongBase
+//
+//  把"图片视频"tab 的所有可浏览项构造为 YBImageBrowser 数据源 (图片+视频混排,
+//  左右滑动可切换), 并挂上自定义 toolbar (右上角 ... 菜单: 定位 / 保存)。
+//
+
+#import <Foundation/Foundation.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryMediaBrowser : NSObject
+
+/// 判定视频项是否有可播放的 URL (服务端字段 或 本地 WKMessageDB 兜底)。
+/// 服务端 messages/_search_media 视频响应目前存在缺 URL 字段的情况;
+/// 若两条来源都拿不到, 调用方应当直接跳会话页定位到该消息 (让 SDK 的下载
+/// + 播放链路兜底), 而不是打开浏览器给用户看一张假的静态封面。
++ (BOOL)isVideoItemPlayable:(WKChannelHistorySearchItem *)item;
+
+/// 打开大图浏览。
+/// @param items       当前 tab 的所有 media 项（保持现有顺序，用作浏览器数据源）
+/// @param tappedItem  用户点击的那一项；内部按"它在最终 dataSource 中的真实位置"定位初始页
+/// @param onLocate   「定位到聊天位置」回调；菜单仅在 messageSeq > 0 时显示
++ (void)presentFromItems:(NSArray<WKChannelHistorySearchItem *> *)items
+                tappedItem:(WKChannelHistorySearchItem *)tappedItem
+                  onLocate:(nullable void(^)(WKChannelHistorySearchItem *item))onLocate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.m
@@ -1,0 +1,170 @@
+//
+//  WKChannelHistoryMediaBrowser.m
+//
+
+#import "WKChannelHistoryMediaBrowser.h"
+#import "WKChannelHistoryMediaBrowserToolbar.h"
+#import "WKChannelHistoryFileDownloader.h"
+#import "WKApp.h"
+#import "WuKongBase.h"
+#import "WKImageBrowser.h"
+#import "WKDefaultWebImageMediator.h"
+#import "WKVideoBrowserData.h"
+#import "WKImageContent.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+#import <YBImageBrowser/YBImageBrowser.h>
+#import <SDWebImage/SDWebImage.h>
+
+@implementation WKChannelHistoryMediaBrowser
+
++ (BOOL)isVideoItemPlayable:(WKChannelHistorySearchItem *)it {
+    if (it.mediaKind != WKChannelHistorySearchMediaKindVideo) return NO;
+    NSString *raw = it.originalUrl.length > 0 ? it.originalUrl : it.previewUrl;
+    if ([self resolveRemoteURL:raw]) return YES;
+    if ([self fallbackVideoURLFromLocalMessage:it]) return YES;
+    return NO;
+}
+
+/// 把服务端返回的 URL 字符串 (可能是完整 URL 也可能是相对路径) 规范化成可播放的 NSURL。
+/// 与 web apiAdapter.normalizeFileUrl 同口径: 已经是 http(s) 就直接用, 否则拼上 apiBaseUrl
+/// (WKApp.getImageFullUrl: 内部就是这个逻辑, 还会走 CDN 重写)。
++ (nullable NSURL *)resolveRemoteURL:(nullable NSString *)raw {
+    NSString *s = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (s.length == 0) return nil;
+    NSString *lower = [s lowercaseString];
+    if ([lower hasPrefix:@"http://"] || [lower hasPrefix:@"https://"]
+        || [lower hasPrefix:@"data:"] || [lower hasPrefix:@"blob:"]
+        || [lower hasPrefix:@"file:"]) {
+        return [NSURL URLWithString:s];
+    }
+    // 相对路径 → 走 WKApp 的 CDN/apiBaseUrl 拼接 (与聊天气泡里点视频一致)
+    return [[WKApp shared] getImageFullUrl:s];
+}
+
+/// 服务端 messages/_search_media 视频响应目前存在缺 URL 字段的情况 (只回
+/// sender/sent_at/media_kind/message_seq/month_bucket)。用 messageSeq + channelId 反查
+/// 本地 WKMessageDB, 从消息 content (小视频消息实际用 WKImageContent 承载)
+/// 拿 remoteUrl, 让浏览器和聊天气泡里点视频走同一份数据源。
++ (nullable NSURL *)fallbackVideoURLFromLocalMessage:(WKChannelHistorySearchItem *)it {
+    if (it.messageSeq <= 0 || it.channelId.length == 0) return nil;
+    WKChannel *ch = [[WKChannel alloc] initWith:it.channelId channelType:it.channelType];
+    WKMessage *msg = [[WKMessageDB shared] getMessage:ch messageSeq:(uint32_t)it.messageSeq];
+    if (![msg.content isKindOfClass:[WKImageContent class]]) return nil;
+    WKImageContent *imgc = (WKImageContent *)msg.content;
+    if (imgc.remoteUrl.length == 0) return nil;
+    return [[WKApp shared] getImageFullUrl:imgc.remoteUrl];
+}
+
+/// 视频项 → WKVideoBrowserData。download 块由 WKChannelHistoryFileDownloader 实现 (命中
+/// tmp 缓存则秒回, 否则边下边播)。封面图先用 SDWebImage 预拉一次, 命中后赋值。
+/// 返回 nil 表示连本地缓存都没有可播 URL —— 调用方会自动回退到 imageData 展示缩略图。
++ (nullable WKVideoBrowserData *)videoDataForItem:(WKChannelHistorySearchItem *)it {
+    NSString *rawSrc = it.originalUrl.length > 0 ? it.originalUrl : it.previewUrl;
+    NSURL *videoURL = [self resolveRemoteURL:rawSrc];
+    // 服务端字段缺失时降级到 WKMessageDB
+    if (!videoURL) videoURL = [self fallbackVideoURLFromLocalMessage:it];
+    if (!videoURL) return nil;
+
+    WKVideoBrowserData *vd = [WKVideoBrowserData new];
+    vd.extraData = @{ @"channelHistoryItem": it };
+
+    NSString *remoteUrl = videoURL.absoluteString;
+    NSString *fileName = it.fileName.length > 0 ? it.fileName : nil;
+    // download 块只会在 cell 真正展示时被调用一次。下载器内部对同 URL 做了 tmp 缓存,
+    // 反复滑动同一条不会重复请求网络。
+    vd.download = ^(void(^downCompleteBlock)(NSString *videoPath, NSError *error)) {
+        [WKChannelHistoryFileDownloader downloadRemoteUrl:remoteUrl
+                                                  fileName:fileName
+                                                   onProgress:nil
+                                                onComplete:^(NSURL *localURL, NSError *error) {
+            if (downCompleteBlock) {
+                downCompleteBlock(localURL.path ?: @"", error);
+            }
+        }];
+    };
+
+    // 预拉封面 (异步) — 拉到了就显示, 拉不到也不阻塞下载。
+    NSURL *thumbURL = [self resolveRemoteURL:(it.thumbUrl.length > 0 ? it.thumbUrl : it.previewUrl)];
+    if (thumbURL) {
+        __weak WKVideoBrowserData *weakVd = vd;
+        [[SDWebImageManager sharedManager]
+         loadImageWithURL:thumbURL
+         options:0
+         progress:nil
+         completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+            if (image) weakVd.coverImage = image;
+        }];
+    }
+    return vd;
+}
+
+/// 图片项 → YBIBImageData。可被视频项当回退路径调用 (优先吃 thumb_url, 因为视频缺
+/// originalUrl 时 thumb_url 通常还在)。
++ (nullable YBIBImageData *)imageDataForItem:(WKChannelHistorySearchItem *)it {
+    NSString *rawSrc = it.originalUrl.length > 0 ? it.originalUrl : it.previewUrl;
+    if (rawSrc.length == 0) rawSrc = it.thumbUrl;
+    NSURL *url = [self resolveRemoteURL:rawSrc];
+    // 服务端 media hit 完全没 URL: 试试从本地消息 content 拿 remoteUrl
+    if (!url) url = [self fallbackVideoURLFromLocalMessage:it]; // 同样能兜住图片消息
+    if (!url) return nil;
+    YBIBImageData *id_ = [YBIBImageData new];
+    id_.imageURL = url;
+    id_.extraData = @{ @"channelHistoryItem": it };
+    id_.allowSaveToPhotoAlbum = YES;
+    return id_;
+}
+
+/// 统一构造数据项。视频构造失败 (缺播放 URL) 自动回退为图片 (展示缩略图), 这样
+/// dataSource 与 items 的位置 1:1 对齐, 永远不会出现「点视频却开到第一张图」的错位。
++ (nullable id<YBIBDataProtocol>)dataForItem:(WKChannelHistorySearchItem *)it {
+    if (it.mediaKind == WKChannelHistorySearchMediaKindVideo) {
+        WKVideoBrowserData *vd = [self videoDataForItem:it];
+        if (vd) return vd;
+    }
+    return [self imageDataForItem:it];
+}
+
++ (void)presentFromItems:(NSArray<WKChannelHistorySearchItem *> *)items
+                tappedItem:(WKChannelHistorySearchItem *)tappedItem
+                  onLocate:(void(^)(WKChannelHistorySearchItem *))onLocate {
+    if (items.count == 0) return;
+
+    NSMutableArray<id<YBIBDataProtocol>> *dataSource = [NSMutableArray arrayWithCapacity:items.count];
+    NSInteger initial = -1;
+
+    // 关键修复: initial 必须按 dataSource 的实际写入位置算, 不能用 items 下标。
+    // dataForItem: 已经做了 video → image 的回退, 极少真正返回 nil (除非连 thumb 都没),
+    // 因此 tappedItem 几乎一定能落进 dataSource。
+    for (WKChannelHistorySearchItem *it in items) {
+        if (it.kind != WKChannelHistorySearchItemKindMedia) continue;
+        id<YBIBDataProtocol> data = [self dataForItem:it];
+        if (!data) continue;
+        if (tappedItem != nil && it == tappedItem) initial = dataSource.count;
+        [dataSource addObject:data];
+    }
+    if (dataSource.count == 0) return;
+    if (initial < 0) initial = 0; // tappedItem 自身被丢弃 / 未传, 兜底从首项开始
+
+    // 使用 WKImageBrowser (项目封装的 YBImageBrowser 子类) — 必须配 webImageMediator 走
+    // SDWebImage, 否则 YB 默认 mediator 找不到合适的 image loader 会闪退。
+    // 关键差异 vs WKImageMessageCell: 这里不设 conversationContext (搜索场景没有会话上下文)。
+    WKImageBrowser *browser = [[WKImageBrowser alloc] init];
+    browser.webImageMediator = [WKDefaultWebImageMediator new];
+    WKChannelHistoryMediaBrowserToolbar *toolbar = [WKChannelHistoryMediaBrowserToolbar new];
+    toolbar.browser = browser;
+    toolbar.onLocateItem = onLocate;
+    toolbar.totalPages = dataSource.count;
+    toolbar.initialPage = initial;
+    // 用我们自己的 toolbar 替换默认。default toolbar 含分页指示/分享/等, 在搜索场景不需要。
+    browser.toolViewHandlers = @[toolbar];
+    // 把 toolbar 设为 browser delegate 以接收 pageChanged: — WKImageBrowser 自身的
+    // delegate 是用于 flame 消息的 currentDataDelegate, 搜索场景不涉及, 可被覆盖。
+    browser.delegate = toolbar;
+    browser.dataSourceArray = dataSource;
+    // currentPage 必须在 dataSourceArray 之后赋值（YBImageBrowser 文档约定，
+    // 否则会先按 0 渲染再跳转，出现"首屏闪一下"）。
+    browser.currentPage = initial;
+    [browser showToView:[WKApp.shared findWindow]];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowser.m
@@ -5,11 +5,11 @@
 #import "WKChannelHistoryMediaBrowser.h"
 #import "WKChannelHistoryMediaBrowserToolbar.h"
 #import "WKChannelHistoryFileDownloader.h"
+#import "WKChannelHistoryStreamingVideoData.h"
 #import "WKApp.h"
 #import "WuKongBase.h"
 #import "WKImageBrowser.h"
 #import "WKDefaultWebImageMediator.h"
-#import "WKVideoBrowserData.h"
 #import "WKImageContent.h"
 #import <WuKongIMSDK/WuKongIMSDK.h>
 #import <YBImageBrowser/YBImageBrowser.h>
@@ -55,38 +55,37 @@
     return [[WKApp shared] getImageFullUrl:imgc.remoteUrl];
 }
 
-/// 视频项 → WKVideoBrowserData。download 块由 WKChannelHistoryFileDownloader 实现 (命中
-/// tmp 缓存则秒回, 否则边下边播)。封面图先用 SDWebImage 预拉一次, 命中后赋值。
-/// 返回 nil 表示连本地缓存都没有可播 URL —— 调用方会自动回退到 imageData 展示缩略图。
-+ (nullable WKVideoBrowserData *)videoDataForItem:(WKChannelHistorySearchItem *)it {
+/// 视频项 → WKChannelHistoryStreamingVideoData。
+/// 数据源: 服务端 URL / 本地 WKMessageDB 消息 content, 二者任一都优先; 再判 tmp 缓存
+/// 命中就走 file:// 起播 (瞬间), 否则给远端 URL 让 AVPlayer 边下边播 (中央 spinner)。
+/// 返回 nil 表示两条来源都拿不到 URL —— 调用方会自动回退到 imageData 展示缩略图。
++ (nullable WKChannelHistoryStreamingVideoData *)videoDataForItem:(WKChannelHistorySearchItem *)it {
     NSString *rawSrc = it.originalUrl.length > 0 ? it.originalUrl : it.previewUrl;
-    NSURL *videoURL = [self resolveRemoteURL:rawSrc];
+    NSURL *remote = [self resolveRemoteURL:rawSrc];
     // 服务端字段缺失时降级到 WKMessageDB
-    if (!videoURL) videoURL = [self fallbackVideoURLFromLocalMessage:it];
-    if (!videoURL) return nil;
+    if (!remote) remote = [self fallbackVideoURLFromLocalMessage:it];
+    if (!remote) return nil;
 
-    WKVideoBrowserData *vd = [WKVideoBrowserData new];
-    vd.extraData = @{ @"channelHistoryItem": it };
-
-    NSString *remoteUrl = videoURL.absoluteString;
+    NSString *remoteStr = remote.absoluteString;
     NSString *fileName = it.fileName.length > 0 ? it.fileName : nil;
-    // download 块只会在 cell 真正展示时被调用一次。下载器内部对同 URL 做了 tmp 缓存,
-    // 反复滑动同一条不会重复请求网络。
-    vd.download = ^(void(^downCompleteBlock)(NSString *videoPath, NSError *error)) {
-        [WKChannelHistoryFileDownloader downloadRemoteUrl:remoteUrl
-                                                  fileName:fileName
-                                                   onProgress:nil
-                                                onComplete:^(NSURL *localURL, NSError *error) {
-            if (downCompleteBlock) {
-                downCompleteBlock(localURL.path ?: @"", error);
-            }
-        }];
-    };
 
-    // 预拉封面 (异步) — 拉到了就显示, 拉不到也不阻塞下载。
+    WKChannelHistoryStreamingVideoData *vd = [WKChannelHistoryStreamingVideoData new];
+    vd.extraData = @{ @"channelHistoryItem": it };
+    vd.remoteURLString = remoteStr;
+    vd.fileName = fileName;
+
+    // 缓存命中: 之前保存到相册 / 别处下过 → 用 file:// 起播 (0 延迟)
+    NSString *cachedPath = [WKChannelHistoryFileDownloader cachedLocalPathForRemoteUrl:remoteStr fileName:fileName];
+    if (cachedPath.length > 0 && [[NSFileManager defaultManager] fileExistsAtPath:cachedPath]) {
+        vd.videoURL = [NSURL fileURLWithPath:cachedPath];
+    } else {
+        vd.videoURL = remote;
+    }
+
+    // 预拉封面 (异步) — 拉到了就显示, 拉不到 AVPlayer 首帧到位后会自动接管 (readyForDisplay)
     NSURL *thumbURL = [self resolveRemoteURL:(it.thumbUrl.length > 0 ? it.thumbUrl : it.previewUrl)];
     if (thumbURL) {
-        __weak WKVideoBrowserData *weakVd = vd;
+        __weak WKChannelHistoryStreamingVideoData *weakVd = vd;
         [[SDWebImageManager sharedManager]
          loadImageWithURL:thumbURL
          options:0
@@ -118,7 +117,7 @@
 /// dataSource 与 items 的位置 1:1 对齐, 永远不会出现「点视频却开到第一张图」的错位。
 + (nullable id<YBIBDataProtocol>)dataForItem:(WKChannelHistorySearchItem *)it {
     if (it.mediaKind == WKChannelHistorySearchMediaKindVideo) {
-        WKVideoBrowserData *vd = [self videoDataForItem:it];
+        WKChannelHistoryStreamingVideoData *vd = [self videoDataForItem:it];
         if (vd) return vd;
     }
     return [self imageDataForItem:it];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.h
@@ -1,0 +1,25 @@
+//
+//  WKChannelHistoryMediaBrowserToolbar.h
+//  WuKongBase
+//
+//  搜索"图片视频"大图浏览 toolbar — 顶部固定一条半透明 dark blur navbar:
+//    ← Close     |     "1 / N"     |     "..." (定位 / 保存)
+//  解决纯 floating 按钮在白图上失明的问题。
+//
+
+#import <Foundation/Foundation.h>
+#import <YBImageBrowser/YBImageBrowser.h>
+#import "WKChannelHistorySearchModels.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryMediaBrowserToolbar : NSObject <YBIBToolViewHandler, YBImageBrowserDelegate>
+
+@property (nonatomic, weak, nullable) YBImageBrowser *browser;
+@property (nonatomic, copy, nullable) void(^onLocateItem)(WKChannelHistorySearchItem *item);
+@property (nonatomic, assign) NSInteger totalPages;
+@property (nonatomic, assign) NSInteger initialPage;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.m
@@ -1,0 +1,182 @@
+//
+//  WKChannelHistoryMediaBrowserToolbar.m
+//
+
+#import "WKChannelHistoryMediaBrowserToolbar.h"
+#import "WKApp.h"
+#import "WuKongBase.h"
+#import "UIView+WK.h"
+#import "UIView+WKCommon.h"
+#import "WKActionSheetView2.h"
+#import "WKActionSheetItem2.h"
+#import "WKConstant.h"
+#import "WKVideoBrowserData.h"
+
+#define kTopBarHeight 44.0f
+
+@interface WKChannelHistoryMediaBrowserToolbar ()
+@property (nonatomic, strong) UIView *topBar;
+@property (nonatomic, strong) UIVisualEffectView *topBarBg;
+@property (nonatomic, strong) UIButton *closeButton;
+@property (nonatomic, strong) UILabel *pageLabel;
+@property (nonatomic, strong) UIButton *moreButton;
+@end
+
+@implementation WKChannelHistoryMediaBrowserToolbar
+
+@synthesize yb_containerView = _yb_containerView;
+@synthesize yb_currentData = _yb_currentData;
+@synthesize yb_containerSize = _yb_containerSize;
+@synthesize yb_currentOrientation = _yb_currentOrientation;
+
+#pragma mark - YBIBToolViewHandler
+
+- (void)yb_containerViewIsReadied {
+    UIView *container = self.yb_containerView;
+    if (!container) return;
+
+    CGFloat topSafe = 0;
+    if (@available(iOS 11.0, *)) {
+        topSafe = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    }
+    CGFloat w = WKScreenWidth;
+    CGFloat barH = topSafe + kTopBarHeight;
+    self.topBar.frame = CGRectMake(0, 0, w, barH);
+    [container addSubview:self.topBar];
+
+    self.topBarBg.frame = self.topBar.bounds;
+    self.closeButton.frame = CGRectMake(4, topSafe, 44, kTopBarHeight);
+    self.moreButton.frame = CGRectMake(w - 48, topSafe, 44, kTopBarHeight);
+    self.pageLabel.frame = CGRectMake(60, topSafe, w - 120, kTopBarHeight);
+
+    [self refreshPageLabel:self.initialPage];
+}
+
+- (void)yb_hide:(BOOL)hide {
+    self.topBar.hidden = hide;
+}
+
+#pragma mark - YBImageBrowserDelegate (page indicator)
+
+- (void)yb_imageBrowser:(YBImageBrowser *)imageBrowser
+            pageChanged:(NSInteger)page
+                   data:(id<YBIBDataProtocol>)data {
+    [self refreshPageLabel:page];
+}
+
+- (void)refreshPageLabel:(NSInteger)page {
+    if (self.totalPages > 1) {
+        self.pageLabel.text = [NSString stringWithFormat:@"%ld / %ld",
+                                (long)(page + 1), (long)self.totalPages];
+        self.pageLabel.hidden = NO;
+    } else {
+        self.pageLabel.hidden = YES;
+    }
+}
+
+#pragma mark - actions
+
+- (void)onCloseTap {
+    [self.browser hide];
+}
+
+- (WKChannelHistorySearchItem *)currentItem {
+    id<YBIBDataProtocol> data = self.yb_currentData ? self.yb_currentData() : nil;
+    if (!data) return nil;
+    id extra = nil;
+    if ([data isKindOfClass:[YBIBImageData class]]) {
+        extra = ((YBIBImageData *)data).extraData;
+    } else if ([data isKindOfClass:[WKVideoBrowserData class]]) {
+        extra = ((WKVideoBrowserData *)data).extraData;
+    }
+    if ([extra isKindOfClass:[NSDictionary class]]) {
+        id it = ((NSDictionary *)extra)[@"channelHistoryItem"];
+        if ([it isKindOfClass:[WKChannelHistorySearchItem class]]) return (WKChannelHistorySearchItem *)it;
+    }
+    return nil;
+}
+
+- (void)onMoreTap {
+    __weak typeof(self) ws = self;
+    WKActionSheetView2 *sheet = [WKActionSheetView2 initWithTip:nil];
+    WKChannelHistorySearchItem *item = [self currentItem];
+    if (item.canLocate && self.onLocateItem) {
+        [sheet addItem:[WKActionSheetButtonItem2 initWithTitle:LLang(@"定位到聊天位置") onClick:^{
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            // 先收起浏览器, 再走定位 — 避免浏览器盖在聊天页上面。
+            [ss.browser hide];
+            if (ss.onLocateItem) ss.onLocateItem(item);
+        }]];
+    }
+    id<YBIBDataProtocol> data = self.yb_currentData ? self.yb_currentData() : nil;
+    BOOL isVideo = [data isKindOfClass:[WKVideoBrowserData class]];
+    NSString *saveTitle = isVideo ? LLang(@"保存视频到相册") : LLang(@"保存图片到相册");
+    [sheet addItem:[WKActionSheetButtonItem2 initWithTitle:saveTitle onClick:^{
+        id<YBIBDataProtocol> cur = ws.yb_currentData ? ws.yb_currentData() : nil;
+        if (cur && cur.yb_allowSaveToPhotoAlbum) {
+            [cur yb_saveToPhotoAlbum];
+        }
+    }]];
+    [sheet show];
+}
+
+#pragma mark - lazy
+
+- (UIView *)topBar {
+    if (!_topBar) {
+        _topBar = [[UIView alloc] init];
+        _topBar.backgroundColor = [UIColor clearColor];
+        // dark blur 始终可读, 不管底图什么颜色。透明度按 0.3 保留更多底图可视性 —
+        // 配合 dark blur 的微反差, 文案/图标依旧清晰。
+        UIBlurEffect *blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+        _topBarBg = [[UIVisualEffectView alloc] initWithEffect:blur];
+        _topBarBg.alpha = 0.3;
+        [_topBar addSubview:_topBarBg];
+        [_topBar addSubview:self.closeButton];
+        [_topBar addSubview:self.pageLabel];
+        [_topBar addSubview:self.moreButton];
+    }
+    return _topBar;
+}
+
+- (UIButton *)closeButton {
+    if (!_closeButton) {
+        _closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        [_closeButton setTitle:@"✕" forState:UIControlStateNormal];
+        [_closeButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+        _closeButton.titleLabel.font = [UIFont systemFontOfSize:20 weight:UIFontWeightMedium];
+        [_closeButton addTarget:self action:@selector(onCloseTap) forControlEvents:UIControlEventTouchUpInside];
+    }
+    return _closeButton;
+}
+
+- (UILabel *)pageLabel {
+    if (!_pageLabel) {
+        _pageLabel = [UILabel new];
+        _pageLabel.textColor = [UIColor whiteColor];
+        _pageLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+        _pageLabel.textAlignment = NSTextAlignmentCenter;
+    }
+    return _pageLabel;
+}
+
+- (UIButton *)moreButton {
+    if (!_moreButton) {
+        _moreButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        UIImage *img = [WKApp.shared loadImage:@"Common/Index/More" moduleID:@"WuKongBase"];
+        if (img) {
+            [_moreButton setImage:[img imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
+                          forState:UIControlStateNormal];
+            _moreButton.tintColor = [UIColor whiteColor];
+        } else {
+            [_moreButton setTitle:@"⋯" forState:UIControlStateNormal];
+            [_moreButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+            _moreButton.titleLabel.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+        }
+        [_moreButton addTarget:self action:@selector(onMoreTap) forControlEvents:UIControlEventTouchUpInside];
+    }
+    return _moreButton;
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryMediaBrowserToolbar.m
@@ -3,6 +3,7 @@
 //
 
 #import "WKChannelHistoryMediaBrowserToolbar.h"
+#import "WKChannelHistoryStreamingVideoData.h"
 #import "WKApp.h"
 #import "WuKongBase.h"
 #import "UIView+WK.h"
@@ -10,7 +11,6 @@
 #import "WKActionSheetView2.h"
 #import "WKActionSheetItem2.h"
 #import "WKConstant.h"
-#import "WKVideoBrowserData.h"
 
 #define kTopBarHeight 44.0f
 
@@ -86,8 +86,8 @@
     id extra = nil;
     if ([data isKindOfClass:[YBIBImageData class]]) {
         extra = ((YBIBImageData *)data).extraData;
-    } else if ([data isKindOfClass:[WKVideoBrowserData class]]) {
-        extra = ((WKVideoBrowserData *)data).extraData;
+    } else if ([data isKindOfClass:[WKChannelHistoryStreamingVideoData class]]) {
+        extra = ((WKChannelHistoryStreamingVideoData *)data).extraData;
     }
     if ([extra isKindOfClass:[NSDictionary class]]) {
         id it = ((NSDictionary *)extra)[@"channelHistoryItem"];
@@ -110,7 +110,7 @@
         }]];
     }
     id<YBIBDataProtocol> data = self.yb_currentData ? self.yb_currentData() : nil;
-    BOOL isVideo = [data isKindOfClass:[WKVideoBrowserData class]];
+    BOOL isVideo = [data isKindOfClass:[WKChannelHistoryStreamingVideoData class]];
     NSString *saveTitle = isVideo ? LLang(@"保存视频到相册") : LLang(@"保存图片到相册");
     [sheet addItem:[WKActionSheetButtonItem2 initWithTitle:saveTitle onClick:^{
         id<YBIBDataProtocol> cur = ws.yb_currentData ? ws.yb_currentData() : nil;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.h
@@ -1,0 +1,14 @@
+//
+//  WKChannelHistoryStreamingVideoCell.h
+//  WuKongBase
+//
+
+#import <UIKit/UIKit.h>
+#import <YBImageBrowser/YBIBCellProtocol.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryStreamingVideoCell : UICollectionViewCell <YBIBCellProtocol>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
@@ -1,0 +1,296 @@
+//
+//  WKChannelHistoryStreamingVideoCell.m
+//
+//  流式视频 cell —— AVPlayer 直接吃 URL, 中央 loading 转圈, 首帧到位后隐藏封面。
+//  行为对齐主流视频浏览器 (WeChat / 抖音):
+//    · 进入 cell 立即起播 (autoplay), 不必等下载完
+//    · 缓冲/未就绪 → 中央 UIActivityIndicator
+//    · 首帧 (AVPlayerLayer.readyForDisplay=YES) → 隐藏封面
+//    · 单击 → 切换 播放/暂停
+//    · 播放到尾 → 循环重播
+//    · cell 滚出屏幕 (prepareForReuse) → 暂停 + 拆 KVO / 通知
+//    · App 进后台 → 暂停音频 (避免锁屏还在响)
+//
+
+#import "WKChannelHistoryStreamingVideoCell.h"
+#import "WKChannelHistoryStreamingVideoData.h"
+#import "WKApp.h"
+#import "WuKongBase.h"
+#import "UIView+WK.h"
+#import "UIView+WKCommon.h"
+#import <AVFoundation/AVFoundation.h>
+
+static void * kStreamingKVOStatus = &kStreamingKVOStatus;
+static void * kStreamingKVOTimeControl = &kStreamingKVOTimeControl;
+static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
+
+@interface WKChannelHistoryStreamingVideoCell ()
+@property (nonatomic, strong) UIImageView *coverImgView;
+@property (nonatomic, strong) UIView *playerContainer;
+@property (nonatomic, strong) AVPlayer *player;
+@property (nonatomic, strong) AVPlayerLayer *playerLayer;
+@property (nonatomic, strong) UIActivityIndicatorView *loadingView;
+@property (nonatomic, strong) UIView *playIconOverlay;   // 暂停时中央大播放三角
+@property (nonatomic, assign) BOOL didAttachObservers;
+@property (nonatomic, weak) AVPlayerItem *observedItem;
+@end
+
+@implementation WKChannelHistoryStreamingVideoCell
+
+@synthesize yb_cellData = _yb_cellData;
+@synthesize yb_hideBrowser = _yb_hideBrowser;
+@synthesize yb_hideStatusBar = _yb_hideStatusBar;
+@synthesize yb_hideToolViews = _yb_hideToolViews;
+@synthesize yb_selfPage = _yb_selfPage;
+@synthesize yb_containerSize = _yb_containerSize;
+@synthesize yb_currentOrientation = _yb_currentOrientation;
+@synthesize yb_containerView = _yb_containerView;
+@synthesize yb_auxiliaryViewHandler = _yb_auxiliaryViewHandler;
+@synthesize yb_webImageMediator = _yb_webImageMediator;
+@synthesize yb_currentPage = _yb_currentPage;
+@synthesize yb_totalPage = _yb_totalPage;
+@synthesize yb_cellIsInCenter = _yb_cellIsInCenter;
+@synthesize yb_isTransitioning = _yb_isTransitioning;
+@synthesize yb_isShowTransitioning = _yb_isShowTransitioning;
+@synthesize yb_isHideTransitioning = _yb_isHideTransitioning;
+@synthesize yb_isRotating = _yb_isRotating;
+@synthesize yb_backView = _yb_backView;
+@synthesize yb_collectionView = _yb_collectionView;
+
+#pragma mark - init
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.contentView.backgroundColor = [UIColor blackColor];
+
+        _coverImgView = [UIImageView new];
+        _coverImgView.contentMode = UIViewContentModeScaleAspectFit;
+        _coverImgView.clipsToBounds = YES;
+        [self.contentView addSubview:_coverImgView];
+
+        _playerContainer = [UIView new];
+        _playerContainer.backgroundColor = [UIColor clearColor];
+        [self.contentView addSubview:_playerContainer];
+
+        _loadingView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+        _loadingView.color = [UIColor whiteColor];
+        _loadingView.hidesWhenStopped = YES;
+        [self.contentView addSubview:_loadingView];
+
+        _playIconOverlay = [self buildPlayIconOverlay];
+        _playIconOverlay.hidden = YES;
+        [self.contentView addSubview:_playIconOverlay];
+
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
+            initWithTarget:self action:@selector(onTap)];
+        [self.contentView addGestureRecognizer:tap];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                  selector:@selector(onAppDidEnterBackground)
+                                                      name:UIApplicationDidEnterBackgroundNotification
+                                                    object:nil];
+    }
+    return self;
+}
+
+- (UIView *)buildPlayIconOverlay {
+    UIView *v = [UIView new];
+    v.frame = CGRectMake(0, 0, 64, 64);
+    v.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
+    v.layer.cornerRadius = 32;
+    v.layer.masksToBounds = YES;
+    UILabel *tri = [UILabel new];
+    tri.text = @"▶";
+    tri.font = [UIFont systemFontOfSize:28 weight:UIFontWeightMedium];
+    tri.textColor = [UIColor whiteColor];
+    tri.textAlignment = NSTextAlignmentCenter;
+    tri.frame = CGRectMake(4, 0, 64, 64); // 三角形视觉重心偏左, 右移 4pt 让它居中
+    [v addSubview:tri];
+    return v;
+}
+
+- (void)dealloc {
+    [self teardownPlayer];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - layout
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect b = self.contentView.bounds;
+    self.coverImgView.frame = b;
+    self.playerContainer.frame = b;
+    self.playerLayer.frame = self.playerContainer.bounds;
+    self.loadingView.center = CGPointMake(CGRectGetMidX(b), CGRectGetMidY(b));
+    self.playIconOverlay.center = CGPointMake(CGRectGetMidX(b), CGRectGetMidY(b));
+}
+
+#pragma mark - <YBIBCellProtocol>
+
+- (UIView *)yb_foregroundView {
+    return self.coverImgView;
+}
+
+- (void)yb_pageChanged {
+    // 页码变化后, 若本 cell 不再是中心项 → 暂停播放, 避免用户翻页后还在放音。
+    BOOL isCenter = self.yb_cellIsInCenter ? self.yb_cellIsInCenter() : NO;
+    if (!isCenter && self.player) {
+        [self.player pause];
+        [self refreshPlayIconVisibility];
+    }
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self teardownPlayer];
+    self.coverImgView.image = nil;
+    self.coverImgView.hidden = NO;
+    self.playIconOverlay.hidden = YES;
+    [self.loadingView stopAnimating];
+}
+
+- (void)setYb_cellData:(id<YBIBDataProtocol>)yb_cellData {
+    _yb_cellData = yb_cellData;
+    if (![yb_cellData isKindOfClass:[WKChannelHistoryStreamingVideoData class]]) return;
+    WKChannelHistoryStreamingVideoData *data = (WKChannelHistoryStreamingVideoData *)yb_cellData;
+
+    self.coverImgView.image = data.coverImage;
+    self.coverImgView.hidden = (data.coverImage == nil);
+
+    [self teardownPlayer];
+    if (!data.videoURL) {
+        // 无 URL: 只显示 cover + 一个错误 toast (不 spinner, 会一直转)。
+        id<YBIBAuxiliaryViewHandler> aux = self.yb_auxiliaryViewHandler ? self.yb_auxiliaryViewHandler() : nil;
+        [aux yb_showIncorrectToastWithContainer:self text:LLang(@"视频不可用")];
+        return;
+    }
+
+    // 起播: AVPlayer 直接吃 URL (file:// 或 https://) — AVFoundation 内部会做流式 range
+    // 请求 / HLS 处理。首帧到位前的空档由 spinner + cover 遮盖。
+    AVPlayerItem *item = [AVPlayerItem playerItemWithURL:data.videoURL];
+    self.player = [AVPlayer playerWithPlayerItem:item];
+    self.player.actionAtItemEnd = AVPlayerActionAtItemEndNone; // 手动 loop
+    self.playerLayer = [AVPlayerLayer playerLayerWithPlayer:self.player];
+    self.playerLayer.videoGravity = AVLayerVideoGravityResizeAspect;
+    self.playerLayer.frame = self.playerContainer.bounds;
+    [self.playerContainer.layer addSublayer:self.playerLayer];
+
+    [item addObserver:self forKeyPath:@"status" options:0 context:kStreamingKVOStatus];
+    [self.player addObserver:self forKeyPath:@"timeControlStatus" options:0 context:kStreamingKVOTimeControl];
+    [self.playerLayer addObserver:self forKeyPath:@"readyForDisplay" options:0 context:kStreamingKVOReadyForDisplay];
+    self.observedItem = item;
+    self.didAttachObservers = YES;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                              selector:@selector(onItemDidPlayToEnd:)
+                                                  name:AVPlayerItemDidPlayToEndTimeNotification
+                                                object:item];
+
+    // 起播前 spinner 转起来 (readyForDisplay 或 status=readyToPlay 后再关闭)
+    [self.loadingView startAnimating];
+    self.playIconOverlay.hidden = YES;
+    [self.player play];
+    [self setNeedsLayout];
+}
+
+- (void)onAppDidEnterBackground {
+    [self.player pause];
+    [self refreshPlayIconVisibility];
+}
+
+#pragma mark - KVO
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+    if (context != kStreamingKVOStatus
+        && context != kStreamingKVOTimeControl
+        && context != kStreamingKVOReadyForDisplay) {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        return;
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self refreshLoadingVisibility];
+        if (context == kStreamingKVOReadyForDisplay && self.playerLayer.readyForDisplay) {
+            self.coverImgView.hidden = YES;
+        }
+        if (context == kStreamingKVOStatus && self.observedItem.status == AVPlayerItemStatusFailed) {
+            [self.loadingView stopAnimating];
+            id<YBIBAuxiliaryViewHandler> aux = self.yb_auxiliaryViewHandler ? self.yb_auxiliaryViewHandler() : nil;
+            [aux yb_showIncorrectToastWithContainer:self text:LLang(@"视频加载失败")];
+        }
+    });
+}
+
+- (void)refreshLoadingVisibility {
+    if (!self.player) {
+        [self.loadingView stopAnimating];
+        return;
+    }
+    BOOL loading = NO;
+    if (self.observedItem.status == AVPlayerItemStatusUnknown) loading = YES;
+    // waitingToPlayAtSpecifiedRate = 因缓冲/无网/其它原因暂停等待
+    if (self.player.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) loading = YES;
+    if (loading) {
+        [self.loadingView startAnimating];
+        self.playIconOverlay.hidden = YES;
+    } else {
+        [self.loadingView stopAnimating];
+        [self refreshPlayIconVisibility];
+    }
+}
+
+- (void)refreshPlayIconVisibility {
+    // 只在明确暂停时显示中央播放三角。播放中 / 加载中都藏起来。
+    BOOL paused = (self.player.timeControlStatus == AVPlayerTimeControlStatusPaused);
+    BOOL loading = (self.player.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate);
+    self.playIconOverlay.hidden = !(paused && !loading);
+}
+
+- (void)onItemDidPlayToEnd:(NSNotification *)note {
+    if (note.object != self.observedItem) return;
+    [self.player seekToTime:kCMTimeZero];
+    [self.player play];
+}
+
+#pragma mark - tap
+
+- (void)onTap {
+    if (!self.player) return;
+    if (self.player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
+        [self.player play];
+    } else if (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+        [self.player pause];
+    }
+    // waiting 状态下不响应, 让 spinner 继续转; 用户可以稍后再点
+    [self refreshPlayIconVisibility];
+}
+
+#pragma mark - teardown
+
+- (void)teardownPlayer {
+    if (self.didAttachObservers) {
+        @try { [self.observedItem removeObserver:self forKeyPath:@"status" context:kStreamingKVOStatus]; }
+        @catch (__unused NSException *e) {}
+        @try { [self.player removeObserver:self forKeyPath:@"timeControlStatus" context:kStreamingKVOTimeControl]; }
+        @catch (__unused NSException *e) {}
+        @try { [self.playerLayer removeObserver:self forKeyPath:@"readyForDisplay" context:kStreamingKVOReadyForDisplay]; }
+        @catch (__unused NSException *e) {}
+        self.didAttachObservers = NO;
+    }
+    if (self.observedItem) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                        name:AVPlayerItemDidPlayToEndTimeNotification
+                                                      object:self.observedItem];
+        self.observedItem = nil;
+    }
+    [self.player pause];
+    self.player = nil;
+    [self.playerLayer removeFromSuperlayer];
+    self.playerLayer = nil;
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
@@ -333,7 +333,23 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
+    // weak-strong + object == observed 双重保护 (PR #64 review Octo-Q + yujiawei
+    // 共同 P2)。dispatch_async 会 retain block 里的 self, cell 在 dealloc 后
+    // block 才 drain 会短暂延后释放; 更重要的是 prepareForReuse → teardownPlayer
+    // 后再 setYb_cellData: 换新 item, 旧 KVO 的 in-flight callback 到 main 时
+    // observedItem/player/playerLayer 已经是新的, 不 guard 会用错 item 的状态
+    // 去改新 UI (提前 hide loading / 顶起进度条)。
+    __weak typeof(self) weakSelf = self;
+    id observedObject = object;
     dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) self = weakSelf;
+        if (!self) return;
+        if ((context == kStreamingKVOStatus && observedObject != self.observedItem) ||
+            (context == kStreamingKVOTimeControl && observedObject != self.player) ||
+            (context == kStreamingKVOReadyForDisplay && observedObject != self.playerLayer)) {
+            // 已被 teardown / 换 item, 老回调直接丢弃, 不动新 UI
+            return;
+        }
         [self refreshLoadingVisibility];
         [self syncPlayPauseBtn];
         if (context == kStreamingKVOReadyForDisplay && self.playerLayer.readyForDisplay) {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoCell.m
@@ -2,11 +2,13 @@
 //  WKChannelHistoryStreamingVideoCell.m
 //
 //  流式视频 cell —— AVPlayer 直接吃 URL, 中央 loading 转圈, 首帧到位后隐藏封面。
-//  行为对齐主流视频浏览器 (WeChat / 抖音):
+//  行为对齐主流视频浏览器 (WeChat / iOS Photos):
 //    · 进入 cell 立即起播 (autoplay), 不必等下载完
 //    · 缓冲/未就绪 → 中央 UIActivityIndicator
 //    · 首帧 (AVPlayerLayer.readyForDisplay=YES) → 隐藏封面
-//    · 单击 → 切换 播放/暂停
+//    · 底部进度条: 播/停按钮 + elapsed / total 时间 + slider 支持拖拽 seek
+//    · 单击 → 切换 播放/暂停 + 弹出/收起底部控件
+//    · 播放中 3s 无操作 → 自动隐藏底部控件 (paused 时常驻)
 //    · 播放到尾 → 循环重播
 //    · cell 滚出屏幕 (prepareForReuse) → 暂停 + 拆 KVO / 通知
 //    · App 进后台 → 暂停音频 (避免锁屏还在响)
@@ -24,6 +26,14 @@ static void * kStreamingKVOStatus = &kStreamingKVOStatus;
 static void * kStreamingKVOTimeControl = &kStreamingKVOTimeControl;
 static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
 
+// 底部控件常量 — 集中一处, 后续调节 spacing/字号只在这里改。
+#define kBottomBarHeight     44.0f
+#define kBottomBarHPadding   12.0f
+#define kBottomBarBtnSize    32.0f
+#define kBottomTimeLblW      44.0f  // "00:00" @ 11pt monospaced 够用
+#define kBottomTimeLblLongW  62.0f  // "00:00:00" (>1h 视频)
+#define kAutoHideAfterSec    3.0
+
 @interface WKChannelHistoryStreamingVideoCell ()
 @property (nonatomic, strong) UIImageView *coverImgView;
 @property (nonatomic, strong) UIView *playerContainer;
@@ -33,6 +43,18 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
 @property (nonatomic, strong) UIView *playIconOverlay;   // 暂停时中央大播放三角
 @property (nonatomic, assign) BOOL didAttachObservers;
 @property (nonatomic, weak) AVPlayerItem *observedItem;
+
+// 底部进度条
+@property (nonatomic, strong) UIView *bottomBar;
+@property (nonatomic, strong) UIVisualEffectView *bottomBarBg;
+@property (nonatomic, strong) UIButton *playPauseBtn;
+@property (nonatomic, strong) UILabel *elapsedLbl;
+@property (nonatomic, strong) UISlider *slider;
+@property (nonatomic, strong) UILabel *totalLbl;
+@property (nonatomic, strong) id periodicObserver;   // AVPlayer time observer token
+@property (nonatomic, assign) BOOL isDraggingSlider; // 拖拽期间不被 periodic 更新覆盖
+@property (nonatomic, strong) NSTimer *autoHideTimer;
+@property (nonatomic, assign) CGFloat durationSeconds; // 缓存 duration, 避免重复读 CMTime
 @end
 
 @implementation WKChannelHistoryStreamingVideoCell
@@ -82,6 +104,8 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
         _playIconOverlay.hidden = YES;
         [self.contentView addSubview:_playIconOverlay];
 
+        [self buildBottomBar];
+
         UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
             initWithTarget:self action:@selector(onTap)];
         [self.contentView addGestureRecognizer:tap];
@@ -100,19 +124,72 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     v.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.4];
     v.layer.cornerRadius = 32;
     v.layer.masksToBounds = YES;
-    UILabel *tri = [UILabel new];
-    tri.text = @"▶";
-    tri.font = [UIFont systemFontOfSize:28 weight:UIFontWeightMedium];
-    tri.textColor = [UIColor whiteColor];
-    tri.textAlignment = NSTextAlignmentCenter;
-    tri.frame = CGRectMake(4, 0, 64, 64); // 三角形视觉重心偏左, 右移 4pt 让它居中
-    [v addSubview:tri];
+    // SF Symbol 系统 play.fill — 与 iOS 原生播放器 (AVPlayerViewController) 一致
+    UIImageView *iv = [UIImageView new];
+    iv.contentMode = UIViewContentModeCenter;
+    iv.tintColor = [UIColor whiteColor];
+    if (@available(iOS 13.0, *)) {
+        UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithPointSize:26
+                                                                                            weight:UIImageSymbolWeightMedium];
+        iv.image = [[UIImage systemImageNamed:@"play.fill" withConfiguration:cfg]
+                     imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    }
+    iv.frame = v.bounds;
+    [v addSubview:iv];
     return v;
+}
+
+- (void)buildBottomBar {
+    _bottomBar = [UIView new];
+    _bottomBar.backgroundColor = [UIColor clearColor];
+    _bottomBar.hidden = YES; // 起播前隐藏, item 就绪后再显示
+    [self.contentView addSubview:_bottomBar];
+
+    // dark blur 半透明 0.3 — 与顶部 navbar 风格一致
+    UIBlurEffect *blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+    _bottomBarBg = [[UIVisualEffectView alloc] initWithEffect:blur];
+    _bottomBarBg.alpha = 0.3;
+    [_bottomBar addSubview:_bottomBarBg];
+
+    _playPauseBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+    _playPauseBtn.tintColor = [UIColor whiteColor];
+    // 默认给个 pause 图标, syncPlayPauseBtn 会按 timeControlStatus 覆盖
+    [_playPauseBtn setImage:[self playerSymbol:@"pause.fill"] forState:UIControlStateNormal];
+    [_playPauseBtn addTarget:self action:@selector(onPlayPauseBtnTap) forControlEvents:UIControlEventTouchUpInside];
+    [_bottomBar addSubview:_playPauseBtn];
+
+    UIFont *timeFont = [UIFont monospacedDigitSystemFontOfSize:11 weight:UIFontWeightRegular];
+    _elapsedLbl = [UILabel new];
+    _elapsedLbl.font = timeFont;
+    _elapsedLbl.textColor = [UIColor whiteColor];
+    _elapsedLbl.textAlignment = NSTextAlignmentCenter;
+    _elapsedLbl.text = @"--:--";
+    [_bottomBar addSubview:_elapsedLbl];
+
+    _totalLbl = [UILabel new];
+    _totalLbl.font = timeFont;
+    _totalLbl.textColor = [UIColor whiteColor];
+    _totalLbl.textAlignment = NSTextAlignmentCenter;
+    _totalLbl.text = @"--:--";
+    [_bottomBar addSubview:_totalLbl];
+
+    _slider = [UISlider new];
+    _slider.minimumValue = 0;
+    _slider.maximumValue = 1;
+    _slider.value = 0;
+    _slider.minimumTrackTintColor = [WKApp shared].config.themeColor;
+    _slider.maximumTrackTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.3];
+    _slider.thumbTintColor = [UIColor whiteColor];
+    [_slider addTarget:self action:@selector(onSliderTouchDown) forControlEvents:UIControlEventTouchDown];
+    [_slider addTarget:self action:@selector(onSliderValueChanged) forControlEvents:UIControlEventValueChanged];
+    [_slider addTarget:self action:@selector(onSliderTouchUp) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel];
+    [_bottomBar addSubview:_slider];
 }
 
 - (void)dealloc {
     [self teardownPlayer];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self.autoHideTimer invalidate];
 }
 
 #pragma mark - layout
@@ -125,6 +202,28 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     self.playerLayer.frame = self.playerContainer.bounds;
     self.loadingView.center = CGPointMake(CGRectGetMidX(b), CGRectGetMidY(b));
     self.playIconOverlay.center = CGPointMake(CGRectGetMidX(b), CGRectGetMidY(b));
+
+    // 底部条: 贴 safe area bottom 上方
+    CGFloat safeBot = 0;
+    if (@available(iOS 11.0, *)) {
+        safeBot = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
+    }
+    CGFloat barY = b.size.height - safeBot - kBottomBarHeight;
+    self.bottomBar.frame = CGRectMake(0, barY, b.size.width, kBottomBarHeight + safeBot);
+    self.bottomBarBg.frame = self.bottomBar.bounds;
+
+    CGFloat timeLblW = self.durationSeconds >= 3600.0 ? kBottomTimeLblLongW : kBottomTimeLblW;
+    CGFloat x = kBottomBarHPadding;
+    self.playPauseBtn.frame = CGRectMake(x, 0, kBottomBarBtnSize, kBottomBarHeight);
+    x = CGRectGetMaxX(self.playPauseBtn.frame) + 4.0f;
+    self.elapsedLbl.frame = CGRectMake(x, 0, timeLblW, kBottomBarHeight);
+    x = CGRectGetMaxX(self.elapsedLbl.frame) + 4.0f;
+    CGFloat rightX = self.bottomBar.lim_width - kBottomBarHPadding - timeLblW;
+    self.totalLbl.frame = CGRectMake(rightX, 0, timeLblW, kBottomBarHeight);
+    CGFloat sliderX = x;
+    CGFloat sliderW = rightX - sliderX - 8.0f;
+    if (sliderW < 40) sliderW = 40; // 极窄屏兜底
+    self.slider.frame = CGRectMake(sliderX, (kBottomBarHeight - 20) / 2.0f, sliderW, 20);
 }
 
 #pragma mark - <YBIBCellProtocol>
@@ -138,6 +237,7 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     BOOL isCenter = self.yb_cellIsInCenter ? self.yb_cellIsInCenter() : NO;
     if (!isCenter && self.player) {
         [self.player pause];
+        [self syncPlayPauseBtn];
         [self refreshPlayIconVisibility];
     }
 }
@@ -149,6 +249,14 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     self.coverImgView.hidden = NO;
     self.playIconOverlay.hidden = YES;
     [self.loadingView stopAnimating];
+    // 复位底部条状态
+    self.bottomBar.hidden = YES;
+    self.slider.value = 0;
+    self.elapsedLbl.text = @"--:--";
+    self.totalLbl.text = @"--:--";
+    self.durationSeconds = 0;
+    self.isDraggingSlider = NO;
+    [self cancelAutoHideTimer];
 }
 
 - (void)setYb_cellData:(id<YBIBDataProtocol>)yb_cellData {
@@ -188,16 +296,29 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
                                                   name:AVPlayerItemDidPlayToEndTimeNotification
                                                 object:item];
 
+    // Slider 位置 → 定期回读 AVPlayer.currentTime 更新。0.5s 一次对拖拽预览体感够顺,
+    // 又不至于耗 CPU。拖拽期由 isDraggingSlider 拦住不覆盖。
+    __weak typeof(self) ws = self;
+    self.periodicObserver = [self.player
+        addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(0.5, NSEC_PER_SEC)
+                                     queue:dispatch_get_main_queue()
+                                usingBlock:^(CMTime time) {
+        [ws refreshSliderFromPlayer];
+    }];
+
     // 起播前 spinner 转起来 (readyForDisplay 或 status=readyToPlay 后再关闭)
     [self.loadingView startAnimating];
     self.playIconOverlay.hidden = YES;
     [self.player play];
+    [self syncPlayPauseBtn];
     [self setNeedsLayout];
 }
 
 - (void)onAppDidEnterBackground {
     [self.player pause];
+    [self syncPlayPauseBtn];
     [self refreshPlayIconVisibility];
+    [self showBottomBarAnimated:YES]; // paused → 常驻显示
 }
 
 #pragma mark - KVO
@@ -214,13 +335,28 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     }
     dispatch_async(dispatch_get_main_queue(), ^{
         [self refreshLoadingVisibility];
+        [self syncPlayPauseBtn];
         if (context == kStreamingKVOReadyForDisplay && self.playerLayer.readyForDisplay) {
             self.coverImgView.hidden = YES;
+        }
+        if (context == kStreamingKVOStatus && self.observedItem.status == AVPlayerItemStatusReadyToPlay) {
+            [self refreshDurationFromPlayer];
+            [self showBottomBarAnimated:YES];
+            [self scheduleAutoHideIfPlaying];
         }
         if (context == kStreamingKVOStatus && self.observedItem.status == AVPlayerItemStatusFailed) {
             [self.loadingView stopAnimating];
             id<YBIBAuxiliaryViewHandler> aux = self.yb_auxiliaryViewHandler ? self.yb_auxiliaryViewHandler() : nil;
             [aux yb_showIncorrectToastWithContainer:self text:LLang(@"视频加载失败")];
+        }
+        if (context == kStreamingKVOTimeControl) {
+            // 播放 → 播完 3s 自动隐藏; 暂停 → 常驻显示
+            if (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+                [self scheduleAutoHideIfPlaying];
+            } else {
+                [self cancelAutoHideTimer];
+                [self showBottomBarAnimated:YES];
+            }
         }
     });
 }
@@ -254,18 +390,161 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     if (note.object != self.observedItem) return;
     [self.player seekToTime:kCMTimeZero];
     [self.player play];
+    [self syncPlayPauseBtn];
+}
+
+#pragma mark - progress bar helpers
+
+- (void)refreshSliderFromPlayer {
+    if (self.isDraggingSlider) return;
+    if (!self.player) return;
+    CMTime cur = self.player.currentTime;
+    CGFloat curSec = CMTIME_IS_VALID(cur) ? CMTimeGetSeconds(cur) : 0;
+    if (!isfinite(curSec) || curSec < 0) curSec = 0;
+    self.elapsedLbl.text = [self formatSeconds:curSec];
+    if (self.durationSeconds > 0) {
+        self.slider.value = (float)MIN(1.0, curSec / self.durationSeconds);
+    }
+}
+
+- (void)refreshDurationFromPlayer {
+    CMTime dur = self.observedItem.duration;
+    if (!CMTIME_IS_VALID(dur) || CMTIME_IS_INDEFINITE(dur)) return;
+    CGFloat s = CMTimeGetSeconds(dur);
+    if (!isfinite(s) || s <= 0) return;
+    self.durationSeconds = s;
+    self.totalLbl.text = [self formatSeconds:s];
+    [self setNeedsLayout]; // 视频超过 1h, 时间标签宽度要变
+}
+
+- (NSString *)formatSeconds:(CGFloat)sec {
+    if (!isfinite(sec) || sec < 0) sec = 0;
+    NSInteger total = (NSInteger)sec;
+    NSInteger h = total / 3600;
+    NSInteger m = (total / 60) % 60;
+    NSInteger s = total % 60;
+    if (h > 0) return [NSString stringWithFormat:@"%02ld:%02ld:%02ld", (long)h, (long)m, (long)s];
+    return [NSString stringWithFormat:@"%02ld:%02ld", (long)m, (long)s];
+}
+
+- (void)syncPlayPauseBtn {
+    if (!self.player) return;
+    BOOL playing = (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying)
+        || (self.player.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate);
+    [self.playPauseBtn setImage:[self playerSymbol:playing ? @"pause.fill" : @"play.fill"]
+                        forState:UIControlStateNormal];
+}
+
+/// SF Symbol 播放器图标 (18pt medium) — iOS 13+ 都能用, 更早 iOS 返 nil 让按钮回落到无图。
+- (UIImage *)playerSymbol:(NSString *)name {
+    if (@available(iOS 13.0, *)) {
+        UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithPointSize:18
+                                                                                            weight:UIImageSymbolWeightMedium];
+        return [[UIImage systemImageNamed:name withConfiguration:cfg]
+                 imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    }
+    return nil;
+}
+
+#pragma mark - slider events
+
+- (void)onSliderTouchDown {
+    self.isDraggingSlider = YES;
+    [self cancelAutoHideTimer]; // 拖拽期间不隐藏
+}
+
+- (void)onSliderValueChanged {
+    // 只更新左侧时间预览, 不真 seek — 松手才 seek, 拖拽体感更流畅 (省频繁 IO)
+    if (self.durationSeconds > 0) {
+        CGFloat previewSec = self.slider.value * self.durationSeconds;
+        self.elapsedLbl.text = [self formatSeconds:previewSec];
+    }
+}
+
+- (void)onSliderTouchUp {
+    self.isDraggingSlider = NO;
+    if (!self.player || self.durationSeconds <= 0) return;
+    CGFloat target = self.slider.value * self.durationSeconds;
+    CMTime targetTime = CMTimeMakeWithSeconds(target, NSEC_PER_SEC);
+    // toleranceBefore/After = kCMTimeZero → 精确 seek (稍慢但准), 用户拖拽后期望"就到这"。
+    [self.player seekToTime:targetTime
+             toleranceBefore:kCMTimeZero
+              toleranceAfter:kCMTimeZero];
+    [self scheduleAutoHideIfPlaying];
+}
+
+- (void)onPlayPauseBtnTap {
+    if (!self.player) return;
+    if (self.player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
+        [self.player play];
+    } else {
+        [self.player pause];
+    }
+    [self syncPlayPauseBtn];
+    [self refreshPlayIconVisibility];
+}
+
+#pragma mark - auto hide bottom bar
+
+- (void)showBottomBarAnimated:(BOOL)animated {
+    if (!self.player || self.observedItem.status != AVPlayerItemStatusReadyToPlay) return;
+    if (!self.bottomBar.hidden && self.bottomBar.alpha >= 0.99) return;
+    self.bottomBar.hidden = NO;
+    if (animated) {
+        [UIView animateWithDuration:0.2 animations:^{ self.bottomBar.alpha = 1.0; }];
+    } else {
+        self.bottomBar.alpha = 1.0;
+    }
+}
+
+- (void)hideBottomBarAnimated {
+    if (self.bottomBar.hidden) return;
+    [UIView animateWithDuration:0.2 animations:^{
+        self.bottomBar.alpha = 0.0;
+    } completion:^(BOOL finished) {
+        self.bottomBar.hidden = YES;
+        self.bottomBar.alpha = 1.0;
+    }];
+}
+
+- (void)scheduleAutoHideIfPlaying {
+    [self cancelAutoHideTimer];
+    if (self.player.timeControlStatus != AVPlayerTimeControlStatusPlaying) return;
+    __weak typeof(self) ws = self;
+    self.autoHideTimer = [NSTimer scheduledTimerWithTimeInterval:kAutoHideAfterSec
+                                                          repeats:NO
+                                                            block:^(NSTimer *t) {
+        [ws hideBottomBarAnimated];
+    }];
+}
+
+- (void)cancelAutoHideTimer {
+    [self.autoHideTimer invalidate];
+    self.autoHideTimer = nil;
 }
 
 #pragma mark - tap
 
 - (void)onTap {
     if (!self.player) return;
-    if (self.player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
-        [self.player play];
-    } else if (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
-        [self.player pause];
-    }
     // waiting 状态下不响应, 让 spinner 继续转; 用户可以稍后再点
+    if (self.player.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) return;
+    // 单击: 弹出/收起底部条; 播 ↔ 暂停 通过底部按钮或点中央播放三角来切
+    if (self.bottomBar.hidden || self.bottomBar.alpha < 0.99) {
+        [self showBottomBarAnimated:YES];
+        [self scheduleAutoHideIfPlaying];
+    } else {
+        // 已显示: 播放中 → 隐藏; 暂停中 → 保持
+        if (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+            [self hideBottomBarAnimated];
+            [self cancelAutoHideTimer];
+        } else {
+            // 暂停时二次点 → 恢复播放 (让用户还能靠"点视频"起播, 不必非得点小按钮)
+            [self.player play];
+            [self syncPlayPauseBtn];
+            [self scheduleAutoHideIfPlaying];
+        }
+    }
     [self refreshPlayIconVisibility];
 }
 
@@ -281,6 +560,10 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
         @catch (__unused NSException *e) {}
         self.didAttachObservers = NO;
     }
+    if (self.periodicObserver && self.player) {
+        [self.player removeTimeObserver:self.periodicObserver];
+    }
+    self.periodicObserver = nil;
     if (self.observedItem) {
         [[NSNotificationCenter defaultCenter] removeObserver:self
                                                         name:AVPlayerItemDidPlayToEndTimeNotification
@@ -291,6 +574,7 @@ static void * kStreamingKVOReadyForDisplay = &kStreamingKVOReadyForDisplay;
     self.player = nil;
     [self.playerLayer removeFromSuperlayer];
     self.playerLayer = nil;
+    [self cancelAutoHideTimer];
 }
 
 @end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.h
@@ -1,0 +1,32 @@
+//
+//  WKChannelHistoryStreamingVideoData.h
+//  WuKongBase
+//
+//  搜索"图片视频"tab 大图浏览专用视频数据 —— 直接把 URL (远端 or 本地缓存)
+//  喂给 AVPlayer 做流式播放。命中 WKChannelHistoryFileDownloader 的 tmp
+//  缓存则用 file:// (瞬间起播), 否则走 https 边下边播。
+//
+
+#import <Foundation/Foundation.h>
+#import <YBImageBrowser/YBImageBrowser.h>
+
+@class WKChannelHistorySearchItem;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryStreamingVideoData : NSObject <YBIBDataProtocol>
+
+/// 视频源: 优先本地 file:// (缓存命中), 否则远端 https 流式播放。
+@property (nonatomic, strong) NSURL *videoURL;
+/// 远端 URL — 用于「保存到相册」时按此下载 (即便 videoURL 已经是本地)。
+@property (nonatomic, copy, nullable) NSString *remoteURLString;
+/// 建议下载后保存的文件名, 传给 WKChannelHistoryFileDownloader 做真实名映射。
+@property (nonatomic, copy, nullable) NSString *fileName;
+/// 封面图 (强引用, 用于 AVPlayer 首帧未到位时占位)。
+@property (nonatomic, strong, nullable) UIImage *coverImage;
+/// 业务上下文 (与 YBIBImageData.extraData 同语义) — 搜索项放这里, 供 toolbar 定位使用。
+@property (nonatomic, strong, nullable) id extraData;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.m
@@ -5,6 +5,7 @@
 #import "WKChannelHistoryStreamingVideoData.h"
 #import "WKChannelHistoryStreamingVideoCell.h"
 #import "WKChannelHistoryFileDownloader.h"
+#import "WuKongBase.h"
 #import <Photos/Photos.h>
 #import <YBImageBrowser/YBIBPhotoAlbumManager.h>
 #import <YBImageBrowser/YBIBCopywriter.h>

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Preview/WKChannelHistoryStreamingVideoData.m
@@ -1,0 +1,91 @@
+//
+//  WKChannelHistoryStreamingVideoData.m
+//
+
+#import "WKChannelHistoryStreamingVideoData.h"
+#import "WKChannelHistoryStreamingVideoCell.h"
+#import "WKChannelHistoryFileDownloader.h"
+#import <Photos/Photos.h>
+#import <YBImageBrowser/YBIBPhotoAlbumManager.h>
+#import <YBImageBrowser/YBIBCopywriter.h>
+
+@implementation WKChannelHistoryStreamingVideoData
+
+@synthesize yb_isHideTransitioning = _yb_isHideTransitioning;
+@synthesize yb_currentOrientation = _yb_currentOrientation;
+@synthesize yb_containerSize = _yb_containerSize;
+@synthesize yb_containerView = _yb_containerView;
+@synthesize yb_auxiliaryViewHandler = _yb_auxiliaryViewHandler;
+@synthesize yb_webImageMediator = _yb_webImageMediator;
+@synthesize yb_backView = _yb_backView;
+
+- (Class)yb_classOfCell {
+    return WKChannelHistoryStreamingVideoCell.class;
+}
+
+- (BOOL)yb_allowSaveToPhotoAlbum {
+    return YES;
+}
+
+/// 保存到相册:
+///   1) videoURL 是本地 file:// 且文件存在 → 直接调 UISaveVideoAtPathToSavedPhotosAlbum
+///   2) 否则先走 WKChannelHistoryFileDownloader 拉一份到 tmp, 再保存
+- (void)yb_saveToPhotoAlbum {
+    __weak typeof(self) ws = self;
+    [YBIBPhotoAlbumManager getPhotoAlbumAuthorizationSuccess:^{
+        __strong typeof(ws) ss = ws;
+        if (!ss) return;
+        NSString *localPath = ss.videoURL.isFileURL ? ss.videoURL.path : nil;
+        if (localPath.length > 0
+            && [[NSFileManager defaultManager] fileExistsAtPath:localPath]) {
+            [ss saveLocalPathToAlbum:localPath];
+            return;
+        }
+        NSString *src = ss.remoteURLString.length > 0 ? ss.remoteURLString : ss.videoURL.absoluteString;
+        if (src.length == 0) return;
+        UIView *container = ss.yb_containerView;
+        id<YBIBAuxiliaryViewHandler> aux = ss.yb_auxiliaryViewHandler ? ss.yb_auxiliaryViewHandler() : nil;
+        [aux yb_showLoadingWithContainer:container progress:0];
+        [WKChannelHistoryFileDownloader
+            downloadRemoteUrl:src
+                     fileName:ss.fileName
+                       onProgress:^(double progress) {
+            [aux yb_showLoadingWithContainer:container progress:(CGFloat)progress];
+        }
+                     onComplete:^(NSURL *localURL, NSError *error) {
+            [aux yb_hideLoadingWithContainer:container];
+            if (error || localURL.path.length == 0) {
+                [aux yb_showIncorrectToastWithContainer:container text:LLang(@"保存视频失败")];
+                return;
+            }
+            [ss saveLocalPathToAlbum:localURL.path];
+        }];
+    } failed:^{
+        __strong typeof(ws) ss = ws;
+        id<YBIBAuxiliaryViewHandler> aux = ss.yb_auxiliaryViewHandler ? ss.yb_auxiliaryViewHandler() : nil;
+        [aux yb_showIncorrectToastWithContainer:ss.yb_containerView
+                                            text:[YBIBCopywriter sharedCopywriter].getPhotoAlbumAuthorizationFailed];
+    }];
+}
+
+- (void)saveLocalPathToAlbum:(NSString *)path {
+    if (!UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(path)) {
+        id<YBIBAuxiliaryViewHandler> aux = self.yb_auxiliaryViewHandler ? self.yb_auxiliaryViewHandler() : nil;
+        [aux yb_showIncorrectToastWithContainer:self.yb_containerView text:LLang(@"保存视频失败")];
+        return;
+    }
+    UISaveVideoAtPathToSavedPhotosAlbum(path, self, @selector(savedVideo:didFinishSavingWithError:contextInfo:), NULL);
+}
+
+- (void)savedVideo:(NSString *)path
+    didFinishSavingWithError:(NSError *)error
+    contextInfo:(void *)contextInfo {
+    id<YBIBAuxiliaryViewHandler> aux = self.yb_auxiliaryViewHandler ? self.yb_auxiliaryViewHandler() : nil;
+    if (error) {
+        [aux yb_showIncorrectToastWithContainer:self.yb_containerView text:LLang(@"保存视频失败")];
+    } else {
+        [aux yb_showCorrectToastWithContainer:self.yb_containerView text:LLang(@"保存视频成功")];
+    }
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistoryHighlighter.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistoryHighlighter.h
@@ -1,0 +1,50 @@
+//
+//  WKChannelHistoryHighlighter.h
+//  WuKongBase
+//
+//  搜索结果文本高亮工具。
+//  - 优先解析服务端返回的 <mark>...</mark> 段落（与 web 同口径）
+//  - 兜底：按关键词做大小写不敏感本地高亮
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistoryHighlighter : NSObject
+
+/// 渲染 snippet（可能含 <mark>）为 NSAttributedString。
+/// keyword: 兜底高亮关键词，当 snippet 不含 <mark> 时使用。
+/// font: 基础字号；textColor: 基础颜色；highlightColor: 高亮色（一般主题紫色）。
++ (NSAttributedString *)attributedFromSnippet:(nullable NSString *)snippet
+                                       keyword:(nullable NSString *)keyword
+                                          font:(UIFont *)font
+                                     textColor:(UIColor *)textColor
+                                highlightColor:(UIColor *)highlightColor;
+
+/// 渲染纯文本+关键词高亮（不解析 <mark>）。
++ (NSAttributedString *)attributedFromText:(nullable NSString *)text
+                                    keyword:(nullable NSString *)keyword
+                                       font:(UIFont *)font
+                                  textColor:(UIColor *)textColor
+                             highlightColor:(UIColor *)highlightColor;
+
+/// 以关键词为中心截取上下文片段（与 WKGlobalSearchVM.snippetFromText 同口径）。
+/// 关键词命中位置在中后部时, 居中截取并加 "..." 标识, 保证关键词附近内容可见。
+/// 如果 snippet 已经包含服务端的 <mark> 高亮标签, 不应调用此方法 —— 直接走
+/// attributedFromSnippet:keyword:font:textColor:highlightColor: 即可。
++ (NSString *)centerSnippet:(nullable NSString *)text
+                     keyword:(nullable NSString *)keyword
+                   maxLength:(NSInteger)maxLength;
+
+/// 服务端 snippet 专用居中: 优先按第一个 <mark>...</mark> 的位置作为锚点(比按
+/// 文本 keyword 搜索更准, 因为服务端可能做了词干/模糊匹配, 关键词字符串本身可能
+/// 在 stripMark 后的纯文本里根本找不到)。找不到 <mark> 时降级为 keyword 文本搜索。
+/// 返回值是已 stripMark 的纯文本, 前后按 maxLength 加 "..." 标识。
++ (NSString *)centerSnippetFromServerText:(nullable NSString *)serverText
+                                    keyword:(nullable NSString *)keyword
+                                  maxLength:(NSInteger)maxLength;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistoryHighlighter.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistoryHighlighter.m
@@ -1,0 +1,204 @@
+//
+//  WKChannelHistoryHighlighter.m
+//
+
+#import "WKChannelHistoryHighlighter.h"
+
+@implementation WKChannelHistoryHighlighter
+
+/// 把 snippet 解构成 [(text, isHighlight)...]。
+/// 如果 snippet 完全不含 <mark>，返回 nil 表示走兜底路径。
++ (nullable NSArray<NSDictionary *> *)splitMarkSegments:(NSString *)snippet {
+    if (snippet.length == 0) return nil;
+    NSError *err = nil;
+    static NSRegularExpression *regex = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        regex = [NSRegularExpression regularExpressionWithPattern:@"<mark>([\\s\\S]*?)</mark>"
+                                                          options:NSRegularExpressionCaseInsensitive
+                                                            error:nil];
+    });
+    NSArray<NSTextCheckingResult *> *matches = [regex matchesInString:snippet
+                                                              options:0
+                                                                range:NSMakeRange(0, snippet.length)];
+    if (matches.count == 0) return nil;
+    NSMutableArray<NSDictionary *> *segs = [NSMutableArray array];
+    NSUInteger cursor = 0;
+    for (NSTextCheckingResult *m in matches) {
+        if (m.range.location > cursor) {
+            NSString *plain = [snippet substringWithRange:NSMakeRange(cursor, m.range.location - cursor)];
+            [segs addObject:@{ @"text": plain, @"highlight": @NO }];
+        }
+        NSString *inner = [snippet substringWithRange:[m rangeAtIndex:1]];
+        [segs addObject:@{ @"text": inner ?: @"", @"highlight": @YES }];
+        cursor = NSMaxRange(m.range);
+    }
+    if (cursor < snippet.length) {
+        NSString *tail = [snippet substringWithRange:NSMakeRange(cursor, snippet.length - cursor)];
+        [segs addObject:@{ @"text": tail, @"highlight": @NO }];
+    }
+    return segs;
+}
+
++ (NSAttributedString *)attributedFromSnippet:(NSString *)snippet
+                                       keyword:(NSString *)keyword
+                                          font:(UIFont *)font
+                                     textColor:(UIColor *)textColor
+                                highlightColor:(UIColor *)highlightColor {
+    if (snippet.length == 0) {
+        return [[NSAttributedString alloc] initWithString:@""];
+    }
+    NSArray<NSDictionary *> *segs = [self splitMarkSegments:snippet];
+    if (segs) {
+        NSMutableAttributedString *out = [NSMutableAttributedString new];
+        for (NSDictionary *seg in segs) {
+            NSString *t = seg[@"text"] ?: @"";
+            BOOL hl = [seg[@"highlight"] boolValue];
+            NSDictionary *attrs = @{
+                NSFontAttributeName: font,
+                NSForegroundColorAttributeName: hl ? highlightColor : textColor,
+            };
+            [out appendAttributedString:[[NSAttributedString alloc] initWithString:t attributes:attrs]];
+        }
+        return out;
+    }
+    return [self attributedFromText:snippet
+                              keyword:keyword
+                                 font:font
+                            textColor:textColor
+                       highlightColor:highlightColor];
+}
+
++ (NSAttributedString *)attributedFromText:(NSString *)text
+                                    keyword:(NSString *)keyword
+                                       font:(UIFont *)font
+                                  textColor:(UIColor *)textColor
+                             highlightColor:(UIColor *)highlightColor {
+    NSString *s = text ?: @"";
+    NSMutableAttributedString *out = [[NSMutableAttributedString alloc] initWithString:s attributes:@{
+        NSFontAttributeName: font,
+        NSForegroundColorAttributeName: textColor,
+    }];
+    NSString *needle = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (needle.length == 0 || s.length == 0) return out;
+    NSRange searchRange = NSMakeRange(0, s.length);
+    while (searchRange.location < s.length) {
+        NSRange r = [s rangeOfString:needle
+                              options:NSCaseInsensitiveSearch
+                                range:searchRange];
+        if (r.location == NSNotFound) break;
+        [out addAttribute:NSForegroundColorAttributeName value:highlightColor range:r];
+        NSUInteger next = NSMaxRange(r);
+        searchRange = NSMakeRange(next, s.length - next);
+    }
+    return out;
+}
+
++ (NSString *)centerSnippet:(NSString *)text keyword:(NSString *)keyword maxLength:(NSInteger)maxLength {
+    if (text.length == 0) return @"";
+    if (maxLength <= 0) return @"";
+    NSString *kw = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (kw.length == 0) {
+        return text.length > (NSUInteger)maxLength ? [text substringToIndex:maxLength] : text;
+    }
+    NSRange range = [text rangeOfString:kw options:NSCaseInsensitiveSearch];
+    if (range.location == NSNotFound) {
+        return text.length > (NSUInteger)maxLength
+            ? [NSString stringWithFormat:@"%@...", [text substringToIndex:maxLength]]
+            : text;
+    }
+    return [self centerSubstringInText:text
+                              anchorLoc:range.location
+                              anchorLen:range.length
+                              maxLength:maxLength];
+}
+
++ (NSString *)centerSnippetFromServerText:(NSString *)serverText
+                                    keyword:(NSString *)keyword
+                                  maxLength:(NSInteger)maxLength {
+    if (serverText.length == 0) return @"";
+    if (maxLength <= 0) return @"";
+    static NSRegularExpression *regex;
+    static NSRegularExpression *wsRegex;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        regex = [NSRegularExpression regularExpressionWithPattern:@"<mark>([\\s\\S]*?)</mark>"
+                                                          options:NSRegularExpressionCaseInsensitive
+                                                            error:nil];
+        // 折叠连续空白 (含 \n \t 及多空格) → 单个空格
+        wsRegex = [NSRegularExpression regularExpressionWithPattern:@"\\s+"
+                                                             options:0
+                                                               error:nil];
+    });
+
+    // 关键: 服务端 snippet 常带大量 \n (代码块 / Markdown 列表 / 表格),
+    // UILabel numberOfLines=2 会用光在这些换行上, 关键词附近的真实文字被挤到显示区外。
+    // 先把所有连续空白折叠成单个空格, 再做 <mark> 剥除和居中, 显示效果才是"按文字量"截 2 行。
+    NSString *flatSource = [wsRegex stringByReplacingMatchesInString:serverText
+                                                             options:0
+                                                               range:NSMakeRange(0, serverText.length)
+                                                        withTemplate:@" "];
+    NSTextCheckingResult *first = [regex firstMatchInString:flatSource
+                                                    options:0
+                                                      range:NSMakeRange(0, flatSource.length)];
+    NSString *plain = first ? [self stripMarks:flatSource] : flatSource;
+
+    // 锚点优先级 (关键改动):
+    //   1) 纯文本里能找到 keyword 字符串 → 用它作锚 (最能对齐用户输入)
+    //   2) 服务端 <mark> 存在 → 用第一个 <mark> 位置 (处理服务端做了词干/近义词匹配的情况)
+    //   3) 都没匹配 → 从头截 maxLength + "..."
+    NSString *kw = [keyword stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (kw.length > 0) {
+        NSRange r = [plain rangeOfString:kw options:NSCaseInsensitiveSearch];
+        if (r.location != NSNotFound) {
+            return [self centerSubstringInText:plain
+                                     anchorLoc:r.location
+                                     anchorLen:r.length
+                                     maxLength:maxLength];
+        }
+    }
+    if (first) {
+        NSString *markedWord = [flatSource substringWithRange:[first rangeAtIndex:1]];
+        return [self centerSubstringInText:plain
+                                 anchorLoc:first.range.location
+                                 anchorLen:markedWord.length
+                                 maxLength:maxLength];
+    }
+    return plain.length > (NSUInteger)maxLength
+        ? [NSString stringWithFormat:@"%@...", [plain substringToIndex:maxLength]]
+        : plain;
+}
+
++ (NSString *)stripMarks:(NSString *)html {
+    if (html.length == 0) return @"";
+    NSString *s = [html stringByReplacingOccurrencesOfString:@"<mark>"
+                                                  withString:@""
+                                                     options:NSCaseInsensitiveSearch
+                                                       range:NSMakeRange(0, html.length)];
+    return [s stringByReplacingOccurrencesOfString:@"</mark>"
+                                        withString:@""
+                                           options:NSCaseInsensitiveSearch
+                                             range:NSMakeRange(0, s.length)];
+}
+
+/// 内部工具: 以 (anchorLoc, anchorLen) 为中心, 前后各取 (maxLength - anchorLen)/2 上下文,
+/// 对齐到 composed character sequence 边界, 首尾按需加 "..."。
++ (NSString *)centerSubstringInText:(NSString *)text
+                          anchorLoc:(NSInteger)anchorLoc
+                          anchorLen:(NSInteger)anchorLen
+                          maxLength:(NSInteger)maxLength {
+    if (text.length == 0) return @"";
+    if (anchorLoc < 0 || anchorLoc >= (NSInteger)text.length) return text;
+    NSInteger radius = maxLength - anchorLen;
+    if (radius < 0) radius = 0;
+    NSInteger contextRadius = radius / 2;
+    NSInteger start = MAX(0, anchorLoc - contextRadius);
+    NSInteger end = MIN((NSInteger)text.length, anchorLoc + anchorLen + contextRadius);
+    NSRange safe = [text rangeOfComposedCharacterSequencesForRange:NSMakeRange(start, end - start)];
+    NSString *snippet = [text substringWithRange:safe];
+    if (safe.location > 0) snippet = [NSString stringWithFormat:@"...%@", snippet];
+    if (NSMaxRange(safe) < text.length) snippet = [NSString stringWithFormat:@"%@...", snippet];
+    return snippet;
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistorySearchKeywordUtil.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistorySearchKeywordUtil.h
@@ -1,0 +1,31 @@
+//
+//  WKChannelHistorySearchKeywordUtil.h
+//  WuKongBase
+//
+//  关键词工具：按 composed character sequence 截断到 64，避免在 emoji/组合字中间斩断。
+//  与 web 端 truncateChannelSearchKeyword(value, 64) 同口径。
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern const NSInteger WKChannelHistorySearchKeywordMaxRunes;
+
+@interface WKChannelHistorySearchKeywordUtil : NSObject
+
+/// 按 composed grapheme 计数。
++ (NSInteger)runeCount:(nullable NSString *)keyword;
+
+/// 截断到 maxRunes 个 grapheme。didTruncate 输出是否发生截断。
++ (NSString *)truncate:(nullable NSString *)keyword
+              maxRunes:(NSInteger)maxRunes
+           didTruncate:(BOOL * _Nullable)didTruncate;
+
+/// 默认上限版本（64）。
++ (NSString *)truncateToDefault:(nullable NSString *)keyword
+                    didTruncate:(BOOL * _Nullable)didTruncate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistorySearchKeywordUtil.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/Util/WKChannelHistorySearchKeywordUtil.m
@@ -1,0 +1,51 @@
+//
+//  WKChannelHistorySearchKeywordUtil.m
+//
+
+#import "WKChannelHistorySearchKeywordUtil.h"
+
+const NSInteger WKChannelHistorySearchKeywordMaxRunes = 64;
+
+@implementation WKChannelHistorySearchKeywordUtil
+
++ (NSInteger)runeCount:(NSString *)keyword {
+    if (keyword.length == 0) return 0;
+    __block NSInteger count = 0;
+    [keyword enumerateSubstringsInRange:NSMakeRange(0, keyword.length)
+                                options:NSStringEnumerationByComposedCharacterSequences
+                             usingBlock:^(NSString *substr, NSRange r, NSRange er, BOOL *stop) {
+        count++;
+    }];
+    return count;
+}
+
++ (NSString *)truncate:(NSString *)keyword maxRunes:(NSInteger)maxRunes didTruncate:(BOOL *)didTruncate {
+    if (didTruncate) *didTruncate = NO;
+    if (keyword.length == 0) return keyword ?: @"";
+    if (maxRunes <= 0) {
+        if (didTruncate) *didTruncate = keyword.length > 0;
+        return @"";
+    }
+    // 快路径：UTF-16 长度 <= maxRunes，必然不超
+    if ((NSInteger)keyword.length <= maxRunes) return keyword;
+    __block NSInteger count = 0;
+    __block NSRange cutRange = NSMakeRange(0, keyword.length);
+    [keyword enumerateSubstringsInRange:NSMakeRange(0, keyword.length)
+                                options:NSStringEnumerationByComposedCharacterSequences
+                             usingBlock:^(NSString *substr, NSRange r, NSRange er, BOOL *stop) {
+        count++;
+        if (count == maxRunes) {
+            cutRange = NSMakeRange(0, NSMaxRange(r));
+            *stop = YES;
+        }
+    }];
+    if (count <= maxRunes && cutRange.length == keyword.length) return keyword;
+    if (didTruncate) *didTruncate = YES;
+    return [keyword substringWithRange:cutRange];
+}
+
++ (NSString *)truncateToDefault:(NSString *)keyword didTruncate:(BOOL *)didTruncate {
+    return [self truncate:keyword maxRunes:WKChannelHistorySearchKeywordMaxRunes didTruncate:didTruncate];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.h
@@ -1,0 +1,26 @@
+//
+//  WKChannelHistorySearchVC.h
+//  WuKongBase
+//
+//  群聊 / 私聊 / 子区"查找聊天内容"页 — 纯 API，对齐 web ChannelSearchPanel。
+//  入口位置：
+//   - 群聊/私聊：WKConversationSettingVM 的 `channelsetting.hsitory` row
+//   - 子区：    WKThreadSettingVC 的"查找聊天内容"row
+//
+//  说明：本 VC 不复用全局搜索栈（WKGlobalSearchResultController），与之独立运行。
+//
+
+#import "WKBaseVC.h"
+
+@class WKChannel;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKChannelHistorySearchVC : WKBaseVC
+
+/// 必须在 push 前赋值。
+@property (nonatomic, strong) WKChannel *channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.m
@@ -1,0 +1,708 @@
+//
+//  WKChannelHistorySearchVC.m
+//
+
+#import "WKChannelHistorySearchVC.h"
+#import "WKChannelHistorySearchVM.h"
+#import "WKChannelHistorySearchAPI.h"
+#import "WKChannelHistorySearchKeywordUtil.h"
+#import "WKChannelHistoryMessageCell.h"
+#import "WKChannelHistoryFileCell.h"
+#import "WKChannelHistoryMediaRowCell.h"
+#import "WKChannelHistoryMediaGridCell.h"
+#import "WKChannelHistorySearchEmptyView.h"
+#import "WKChannelHistoryFilterChipBar.h"
+#import "WKChannelHistoryFilterVC.h"
+#import "WKChannelHistoryMediaBrowser.h"
+#import "WKChannelHistoryFilePreviewVC.h"
+#import "WKChannelHistoryFileDownloader.h"
+#import "WKTabbar.h"
+#import "WKApp.h"
+#import "WuKongBase.h"
+#import "UIView+WKCommon.h"
+#import "WKConversationRouter.h"
+#import "WKNetworkListener.h"
+#import "WKNavigationManager.h"
+#import "WKTimeTool.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+#import <MJRefresh/MJRefresh.h>
+
+#define kSearchDebounceMs 300
+#define kSearchBarHeight 36.0f
+#define kTabBarHeight 36.0f
+#define kChipBarHeight 36.0f
+#define kHintBarHeight 32.0f
+#define kOfflineBarHeight 28.0f
+
+@interface WKChannelHistorySearchVC () <
+    UITextFieldDelegate,
+    UITableViewDataSource,
+    UITableViewDelegate,
+    UICollectionViewDataSource,
+    UICollectionViewDelegate,
+    UICollectionViewDelegateFlowLayout,
+    WKChannelHistorySearchVMDelegate,
+    WKNetworkListenerDelegate,
+    WKChannelHistoryFilterVCDelegate
+>
+
+@property (nonatomic, strong) WKChannelHistorySearchVM *vm;
+
+@property (nonatomic, strong) UIView *searchBarContainer;
+@property (nonatomic, strong) UIView *searchInputBg;
+@property (nonatomic, strong) UITextField *searchInput;
+@property (nonatomic, strong) UIButton *clearBtn;
+@property (nonatomic, strong) UIButton *filterBtn;
+
+@property (nonatomic, strong) WKTabbar *tabbar;
+@property (nonatomic, strong) WKChannelHistoryFilterChipBar *chipBar;
+@property (nonatomic, strong) UIView *keywordHintBar;
+@property (nonatomic, strong) UILabel *keywordHintLbl;
+@property (nonatomic, strong) UIView *offlineBar;
+@property (nonatomic, strong) UILabel *offlineLbl;
+
+@property (nonatomic, strong) UITableView *tableView;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) WKChannelHistorySearchEmptyView *emptyView;
+
+@property (nonatomic, assign) BOOL hasShownKeywordLimitToast;
+@property (nonatomic, assign) BOOL didFirstFilterShow;
+
+@end
+
+@implementation WKChannelHistorySearchVC
+
+#pragma mark - lifecycle
+
+- (NSString *)langTitle {
+    return LLang(@"查找聊天内容");
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.title = self.langTitle;
+
+    NSAssert(self.channel != nil, @"WKChannelHistorySearchVC.channel must be set before push");
+    self.vm = [[WKChannelHistorySearchVM alloc] initWithChannel:self.channel];
+    self.vm.delegate = self;
+
+    [self setupNavSearch];
+    [self setupBars];
+    [self setupContent];
+
+    [self refreshOfflineBarVisibility];
+    [self updateBarsForCurrentState];
+
+    [[WKNetworkListener shared] addDelegate:self];
+
+    // 进入页面时光标聚焦搜索框 — 与其它搜索入口一致
+    [self.searchInput becomeFirstResponder];
+}
+
+- (void)dealloc {
+    [[WKNetworkListener shared] removeDelegate:self];
+    [self.vm cancelInFlight];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [self.searchInput resignFirstResponder];
+}
+
+#pragma mark - setup
+
+- (void)setupNavSearch {
+    self.navigationBar.title = self.langTitle;
+
+    // 右上角筛选按钮
+    self.filterBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.filterBtn.titleLabel.font = [[WKApp shared].config appFontOfSize:14.0f];
+    [self.filterBtn setTitle:LLang(@"筛选") forState:UIControlStateNormal];
+    [self.filterBtn setTitleColor:[WKApp shared].config.themeColor forState:UIControlStateNormal];
+    self.filterBtn.frame = CGRectMake(0, 0, 44.0f, 32.0f);
+    [self.filterBtn addTarget:self action:@selector(onFilterTap) forControlEvents:UIControlEventTouchUpInside];
+    self.navigationBar.rightView = self.filterBtn;
+}
+
+- (void)setupBars {
+    // 搜索框：放在导航栏下方 — 不与系统大标题冲突
+    self.searchBarContainer = [UIView new];
+    self.searchBarContainer.backgroundColor = [WKApp shared].config.backgroundColor;
+    [self.view addSubview:self.searchBarContainer];
+
+    UIView *inputBg = [UIView new];
+    inputBg.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.10];
+    inputBg.layer.cornerRadius = kSearchBarHeight / 2.0f;
+    inputBg.layer.masksToBounds = YES;
+    [self.searchBarContainer addSubview:inputBg];
+    self.searchInputBg = inputBg;
+
+    UILabel *iconLbl = [UILabel new];
+    iconLbl.text = @"🔍";
+    iconLbl.font = [UIFont systemFontOfSize:14.0f];
+    iconLbl.textAlignment = NSTextAlignmentCenter;
+    iconLbl.tag = 101;
+    [inputBg addSubview:iconLbl];
+
+    self.searchInput = [UITextField new];
+    self.searchInput.font = [[WKApp shared].config appFontOfSize:15.0f];
+    self.searchInput.textColor = [WKApp shared].config.defaultTextColor;
+    self.searchInput.placeholder = LLang(@"搜索聊天记录");
+    self.searchInput.clearButtonMode = UITextFieldViewModeNever; // 自己画
+    self.searchInput.returnKeyType = UIReturnKeySearch;
+    self.searchInput.delegate = self;
+    self.searchInput.enablesReturnKeyAutomatically = NO;
+    [self.searchInput addTarget:self action:@selector(onSearchInputChanged) forControlEvents:UIControlEventEditingChanged];
+    [inputBg addSubview:self.searchInput];
+
+    self.clearBtn = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.clearBtn setTitle:@"✕" forState:UIControlStateNormal];
+    [self.clearBtn setTitleColor:[UIColor grayColor] forState:UIControlStateNormal];
+    self.clearBtn.titleLabel.font = [UIFont systemFontOfSize:13.0f weight:UIFontWeightMedium];
+    self.clearBtn.hidden = YES;
+    [self.clearBtn addTarget:self action:@selector(onClearTap) forControlEvents:UIControlEventTouchUpInside];
+    [inputBg addSubview:self.clearBtn];
+
+    // Tabbar
+    NSMutableArray<WKTabbarItem *> *items = [NSMutableArray array];
+    [items addObject:[[WKTabbarItem alloc] initWithTitle:LLang(@"全部") onClick:^{ [self switchTabIndex:0]; }]];
+    [items addObject:[[WKTabbarItem alloc] initWithTitle:LLang(@"聊天记录") onClick:^{ [self switchTabIndex:1]; }]];
+    [items addObject:[[WKTabbarItem alloc] initWithTitle:LLang(@"图片视频") onClick:^{ [self switchTabIndex:2]; }]];
+    [items addObject:[[WKTabbarItem alloc] initWithTitle:LLang(@"文件") onClick:^{ [self switchTabIndex:3]; }]];
+    CGFloat space = 16.0f;
+    self.tabbar = [[WKTabbar alloc] initWithItems:items width:WKScreenWidth - space * 2];
+    self.tabbar.lim_left = space;
+    [self.view addSubview:self.tabbar];
+
+    // chip bar
+    self.chipBar = [[WKChannelHistoryFilterChipBar alloc] init];
+    self.chipBar.hidden = YES;
+    [self.view addSubview:self.chipBar];
+
+    // keyword hint bar (media tab)
+    self.keywordHintBar = [UIView new];
+    self.keywordHintBar.backgroundColor = [[UIColor systemYellowColor] colorWithAlphaComponent:0.18];
+    self.keywordHintBar.hidden = YES;
+    self.keywordHintLbl = [UILabel new];
+    self.keywordHintLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+    self.keywordHintLbl.textColor = [UIColor darkGrayColor];
+    self.keywordHintLbl.textAlignment = NSTextAlignmentCenter;
+    self.keywordHintLbl.numberOfLines = 1;
+    self.keywordHintLbl.text = LLang(@"图片和视频暂不支持按关键词搜索，可按发送人或日期查找");
+    [self.keywordHintBar addSubview:self.keywordHintLbl];
+    [self.view addSubview:self.keywordHintBar];
+
+    // offline bar
+    self.offlineBar = [UIView new];
+    self.offlineBar.backgroundColor = [[UIColor systemYellowColor] colorWithAlphaComponent:0.25];
+    self.offlineBar.hidden = YES;
+    self.offlineLbl = [UILabel new];
+    self.offlineLbl.font = [[WKApp shared].config appFontOfSize:12.0f];
+    self.offlineLbl.textColor = [UIColor darkGrayColor];
+    self.offlineLbl.textAlignment = NSTextAlignmentCenter;
+    self.offlineLbl.text = LLang(@"当前网络不可用，请检查网络设置");
+    [self.offlineBar addSubview:self.offlineLbl];
+    [self.view addSubview:self.offlineBar];
+
+    [self.tabbar selectItemAtIndex:0];
+}
+
+- (void)setupContent {
+    // TableView (全部 / 聊天记录 / 文件)
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+    self.tableView.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    self.tableView.dataSource = self;
+    self.tableView.delegate = self;
+    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    [self.tableView registerClass:WKChannelHistoryMessageCell.class
+           forCellReuseIdentifier:[WKChannelHistoryMessageCell reuseIdentifier]];
+    [self.tableView registerClass:WKChannelHistoryFileCell.class
+           forCellReuseIdentifier:[WKChannelHistoryFileCell reuseIdentifier]];
+    [self.tableView registerClass:WKChannelHistoryMediaRowCell.class
+           forCellReuseIdentifier:[WKChannelHistoryMediaRowCell reuseIdentifier]];
+    [self attachLoadMoreFooter:self.tableView];
+    [self.view addSubview:self.tableView];
+
+    // CollectionView (图片视频)
+    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    layout.scrollDirection = UICollectionViewScrollDirectionVertical;
+    layout.minimumInteritemSpacing = 2.0f;
+    layout.minimumLineSpacing = 2.0f;
+    layout.sectionInset = UIEdgeInsetsMake(2, 2, 2, 2);
+    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+    self.collectionView.backgroundColor = [WKApp shared].config.backgroundColor;
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    [self.collectionView registerClass:WKChannelHistoryMediaGridCell.class
+            forCellWithReuseIdentifier:[WKChannelHistoryMediaGridCell reuseIdentifier]];
+    [self attachLoadMoreFooter:self.collectionView];
+    self.collectionView.hidden = YES;
+    [self.view addSubview:self.collectionView];
+
+    // Empty state
+    self.emptyView = [WKChannelHistorySearchEmptyView new];
+    self.emptyView.hidden = YES;
+    __weak typeof(self) ws = self;
+    self.emptyView.onRetry = ^{ [ws.vm refresh]; };
+    [self.view addSubview:self.emptyView];
+}
+
+- (void)attachLoadMoreFooter:(UIScrollView *)sv {
+    __weak typeof(self) ws = self;
+    sv.mj_footer = [MJRefreshAutoNormalFooter footerWithRefreshingBlock:^{ [ws.vm loadMore]; }];
+    sv.mj_footer.hidden = YES;
+}
+
+#pragma mark - layout
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+
+    CGFloat navBottom = [self getNavBottom];
+    CGFloat w = self.view.lim_width;
+
+    // search bar
+    self.searchBarContainer.frame = CGRectMake(0, navBottom, w, kSearchBarHeight + 12.0f);
+    UIView *inputBg = self.searchInputBg;
+    inputBg.frame = CGRectMake(12, 6, w - 24, kSearchBarHeight);
+    UILabel *icon = [inputBg viewWithTag:101];
+    icon.frame = CGRectMake(8, 0, 24, kSearchBarHeight);
+    self.clearBtn.frame = CGRectMake(inputBg.lim_width - 32, 0, 28, kSearchBarHeight);
+    self.searchInput.frame = CGRectMake(CGRectGetMaxX(icon.frame),
+                                        0,
+                                        self.clearBtn.lim_left - CGRectGetMaxX(icon.frame) - 4,
+                                        kSearchBarHeight);
+
+    // tabbar
+    self.tabbar.frame = CGRectMake(16, self.searchBarContainer.lim_bottom, w - 32, kTabBarHeight);
+
+    // chip bar
+    CGFloat y = self.tabbar.lim_bottom + 4.0f;
+    if (!self.chipBar.hidden) {
+        self.chipBar.frame = CGRectMake(0, y, w, kChipBarHeight);
+        y += kChipBarHeight;
+    }
+
+    // keyword hint
+    if (!self.keywordHintBar.hidden) {
+        self.keywordHintBar.frame = CGRectMake(0, y, w, kHintBarHeight);
+        self.keywordHintLbl.frame = CGRectMake(16, 0, w - 32, kHintBarHeight);
+        y += kHintBarHeight;
+    }
+
+    // offline bar
+    if (!self.offlineBar.hidden) {
+        self.offlineBar.frame = CGRectMake(0, y, w, kOfflineBarHeight);
+        self.offlineLbl.frame = CGRectMake(16, 0, w - 32, kOfflineBarHeight);
+        y += kOfflineBarHeight;
+    }
+
+    CGRect contentRect = CGRectMake(0, y, w, self.view.lim_height - y);
+    self.tableView.frame = contentRect;
+    self.collectionView.frame = contentRect;
+    [self updateCollectionItemSize];
+    self.emptyView.frame = contentRect;
+}
+
+- (void)updateCollectionItemSize {
+    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+    CGFloat w = self.collectionView.lim_width;
+    if (w <= 0) return;
+    CGFloat cols = 3.0f;
+    CGFloat gap = layout.minimumInteritemSpacing;
+    CGFloat side = layout.sectionInset.left + layout.sectionInset.right + gap * (cols - 1);
+    CGFloat itemW = floor((w - side) / cols);
+    layout.itemSize = CGSizeMake(itemW, itemW);
+}
+
+#pragma mark - tab switching
+
+- (void)switchTabIndex:(NSInteger)idx {
+    WKChannelHistorySearchTab tab = (WKChannelHistorySearchTab)idx;
+    [self.vm setTab:tab];
+    BOOL isMedia = (tab == WKChannelHistorySearchTabMedia);
+    self.tableView.hidden = isMedia;
+    self.collectionView.hidden = !isMedia;
+    [self updateBarsForCurrentState];
+    [self reloadCurrentList];
+    [self updateEmptyState];
+}
+
+#pragma mark - input
+
+- (void)onSearchInputChanged {
+    UITextField *tf = self.searchInput;
+    self.clearBtn.hidden = (tf.text.length == 0);
+    // IME 中文拼音组合期间不发请求：等 marked text 为 nil 再触发
+    if (tf.markedTextRange != nil) return;
+    [self scheduleDebouncedSearch];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    // 提交时立即触发一次（不等 debounce）
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(applyKeywordNow) object:nil];
+    [self applyKeywordNow];
+    return YES;
+}
+
+- (void)scheduleDebouncedSearch {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(applyKeywordNow) object:nil];
+    [self performSelector:@selector(applyKeywordNow) withObject:nil afterDelay:kSearchDebounceMs / 1000.0];
+}
+
+- (void)applyKeywordNow {
+    [self.vm applyKeyword:self.searchInput.text];
+}
+
+- (void)onClearTap {
+    self.searchInput.text = @"";
+    self.clearBtn.hidden = YES;
+    [self.vm applyKeyword:@""];
+}
+
+#pragma mark - filter
+
+- (void)onFilterTap {
+    WKChannelHistoryFilterVC *vc = [WKChannelHistoryFilterVC new];
+    vc.channel = self.channel;
+    vc.draft = [self.vm.filter copy];
+    vc.delegate = self;
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+    nav.modalPresentationStyle = UIModalPresentationFormSheet;
+    [self presentViewController:nav animated:YES completion:nil];
+}
+
+- (void)channelHistoryFilterVC:(WKChannelHistoryFilterVC *)vc didApplyFilter:(WKChannelHistorySearchFilter *)filter {
+    [vc dismissViewControllerAnimated:YES completion:nil];
+    [self.vm applyFilter:filter];
+}
+
+#pragma mark - VM delegate
+
+- (void)channelHistorySearchVMDidChangeState:(WKChannelHistorySearchVM *)vm {
+    [self reloadCurrentList];
+    [self updateEmptyState];
+    [self updateLoadMoreFooter];
+    [self updateChipBar];
+    [self updateKeywordHintBar];
+    [self.view setNeedsLayout];
+}
+
+- (void)channelHistorySearchVMKeywordExceedLimit:(WKChannelHistorySearchVM *)vm {
+    if (self.hasShownKeywordLimitToast) return;
+    self.hasShownKeywordLimitToast = YES;
+    [self.view showMsg:[NSString stringWithFormat:LLang(@"关键词最多 %ld 个字"),
+                          (long)WKChannelHistorySearchKeywordMaxRunes]];
+}
+
+- (void)reloadCurrentList {
+    if (self.collectionView.hidden == NO) {
+        [self.collectionView reloadData];
+    } else {
+        [self.tableView reloadData];
+    }
+}
+
+- (void)updateLoadMoreFooter {
+    UIScrollView *sv = self.collectionView.hidden ? self.tableView : self.collectionView;
+    BOOL hasContent = self.vm.items.count > 0;
+    sv.mj_footer.hidden = !hasContent;
+    if (self.vm.nextPageError) {
+        [sv.mj_footer endRefreshing];
+        [self.view showMsg:LLang(@"加载更多失败，请重试")];
+    } else if (self.vm.isLoadingNextPage) {
+        // MJRefresh footer 在 loadMore 时自动转 — 不主动调
+    } else if (!self.vm.hasMore && hasContent) {
+        [sv.mj_footer endRefreshingWithNoMoreData];
+    } else {
+        [sv.mj_footer endRefreshing];
+        [sv.mj_footer resetNoMoreData];
+    }
+}
+
+- (void)updateEmptyState {
+    BOOL hasItems = self.vm.items.count > 0;
+    if (hasItems) {
+        self.emptyView.hidden = YES;
+        return;
+    }
+    self.emptyView.hidden = NO;
+    if ([WKNetworkListener shared].hasNetwork == NO) {
+        [self.emptyView applyMode:WKChannelHistorySearchEmptyModeOffline primary:nil secondary:nil];
+        return;
+    }
+    if (self.vm.firstPageError) {
+        [self.emptyView applyMode:WKChannelHistorySearchEmptyModeError primary:nil secondary:nil];
+        return;
+    }
+    if (self.vm.isLoadingFirstPage) {
+        [self.emptyView applyMode:WKChannelHistorySearchEmptyModeLoading primary:nil secondary:nil];
+        return;
+    }
+    if (!self.vm.queryStarted) {
+        [self.emptyView applyMode:WKChannelHistorySearchEmptyModeWaitingInput primary:nil secondary:nil];
+        return;
+    }
+    [self.emptyView applyMode:WKChannelHistorySearchEmptyModeNoResults primary:nil secondary:nil];
+}
+
+#pragma mark - chip bar
+
+- (void)updateChipBar {
+    NSMutableArray<WKChannelHistoryFilterChipDescriptor *> *chips = [NSMutableArray array];
+    WKChannelHistorySearchFilter *f = self.vm.filter;
+    __weak typeof(self) ws = self;
+    if (f.senderUids.count > 0) {
+        WKChannelHistoryFilterChipDescriptor *c = [WKChannelHistoryFilterChipDescriptor new];
+        c.key = @"sender";
+        c.title = [NSString stringWithFormat:LLang(@"发送人: %ld"), (long)f.senderUids.count];
+        c.onClear = ^{
+            WKChannelHistorySearchFilter *nf = [ws.vm.filter copy];
+            nf.senderUids = nil;
+            [ws.vm applyFilter:nf];
+        };
+        c.onTap = ^{ [ws onFilterTap]; };
+        [chips addObject:c];
+    }
+    if (f.startDate || f.endDate) {
+        WKChannelHistoryFilterChipDescriptor *c = [WKChannelHistoryFilterChipDescriptor new];
+        c.key = @"date";
+        c.title = [self dateRangeLabelFromStart:f.startDate end:f.endDate];
+        c.onClear = ^{
+            WKChannelHistorySearchFilter *nf = [ws.vm.filter copy];
+            nf.startDate = nil;
+            nf.endDate = nil;
+            [ws.vm applyFilter:nf];
+        };
+        c.onTap = ^{ [ws onFilterTap]; };
+        [chips addObject:c];
+    }
+    if (f.sort == WKChannelHistorySearchSortTimeAsc) {
+        WKChannelHistoryFilterChipDescriptor *c = [WKChannelHistoryFilterChipDescriptor new];
+        c.key = @"sort";
+        c.title = LLang(@"时间正序");
+        c.onClear = ^{
+            WKChannelHistorySearchFilter *nf = [ws.vm.filter copy];
+            nf.sort = WKChannelHistorySearchSortTimeDesc;
+            [ws.vm applyFilter:nf];
+        };
+        c.onTap = ^{ [ws onFilterTap]; };
+        [chips addObject:c];
+    }
+    self.chipBar.chips = chips;
+    self.chipBar.hidden = chips.count == 0;
+}
+
+- (NSString *)dateRangeLabelFromStart:(NSDate *)start end:(NSDate *)end {
+    static NSDateFormatter *fmt = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        fmt = [NSDateFormatter new];
+        fmt.dateFormat = @"yyyy/MM/dd";
+    });
+    NSString *s = start ? [fmt stringFromDate:start] : LLang(@"最早");
+    NSString *e = end ? [fmt stringFromDate:end] : LLang(@"至今");
+    return [NSString stringWithFormat:@"%@ ~ %@", s, e];
+}
+
+#pragma mark - bars visibility
+
+- (void)updateBarsForCurrentState {
+    BOOL isMedia = (self.vm.tab == WKChannelHistorySearchTabMedia);
+    BOOL hasKw = self.vm.keyword.length > 0;
+    self.keywordHintBar.hidden = !(isMedia && hasKw);
+    [self.view setNeedsLayout];
+}
+
+- (void)updateKeywordHintBar {
+    [self updateBarsForCurrentState];
+}
+
+#pragma mark - network listener
+
+- (void)networkListenerStatusChange:(WKNetworkListener *)listener {
+    BOOL wasOffline = !self.offlineBar.hidden;
+    [self refreshOfflineBarVisibility];
+    [self updateEmptyState];
+    if (wasOffline && listener.hasNetwork) {
+        // 恢复联网后自动重试当前查询
+        [self.vm refresh];
+    }
+}
+
+- (void)refreshOfflineBarVisibility {
+    BOOL hasNet = [WKNetworkListener shared].hasNetwork;
+    self.offlineBar.hidden = hasNet;
+    [self.view setNeedsLayout];
+}
+
+#pragma mark - UITableViewDataSource / Delegate
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.vm.items.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    WKChannelHistorySearchItem *item = self.vm.items[indexPath.row];
+    NSString *kw = self.vm.keyword;
+    switch (item.kind) {
+        case WKChannelHistorySearchItemKindMessage: {
+            WKChannelHistoryMessageCell *c = [tableView dequeueReusableCellWithIdentifier:[WKChannelHistoryMessageCell reuseIdentifier]
+                                                                              forIndexPath:indexPath];
+            [c applyItem:item keyword:kw];
+            return c;
+        }
+        case WKChannelHistorySearchItemKindFile: {
+            WKChannelHistoryFileCell *c = [tableView dequeueReusableCellWithIdentifier:[WKChannelHistoryFileCell reuseIdentifier]
+                                                                           forIndexPath:indexPath];
+            [c applyItem:item keyword:kw];
+            return c;
+        }
+        case WKChannelHistorySearchItemKindMedia: {
+            WKChannelHistoryMediaRowCell *c = [tableView dequeueReusableCellWithIdentifier:[WKChannelHistoryMediaRowCell reuseIdentifier]
+                                                                              forIndexPath:indexPath];
+            [c applyItem:item keyword:kw];
+            return c;
+        }
+    }
+    return [UITableViewCell new];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    WKChannelHistorySearchItem *item = self.vm.items[indexPath.row];
+    switch (item.kind) {
+        case WKChannelHistorySearchItemKindMessage:
+            return [WKChannelHistoryMessageCell heightForItem:item width:tableView.lim_width];
+        case WKChannelHistorySearchItemKindFile:
+            return [WKChannelHistoryFileCell cellHeight];
+        case WKChannelHistorySearchItemKindMedia:
+            return [WKChannelHistoryMediaRowCell cellHeight];
+    }
+    return 64.0f;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.row >= (NSInteger)self.vm.items.count) return;
+    [self openItem:self.vm.items[indexPath.row]];
+}
+
+#pragma mark - UICollectionView
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return self.vm.items.count;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    WKChannelHistoryMediaGridCell *c = [collectionView dequeueReusableCellWithReuseIdentifier:[WKChannelHistoryMediaGridCell reuseIdentifier]
+                                                                                forIndexPath:indexPath];
+    WKChannelHistorySearchItem *item = self.vm.items[indexPath.item];
+    [c applyItem:item];
+    return c;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.item >= (NSInteger)self.vm.items.count) return;
+    [self openItem:self.vm.items[indexPath.item]];
+}
+
+#pragma mark - tap dispatch
+
+/// 三种 kind 的点击行为各异，整体与气泡内交互对齐:
+///   - 消息 → 跳转到聊天页并定位该消息
+///   - 媒体 → 全屏大图浏览器, 左右滑切换图片/视频, 右上角 "..." 菜单
+///   - 文件 → 下载到本地后用 WKSafeFilePreviewVC 子类预览, 右上角 "..." 菜单
+- (void)openItem:(WKChannelHistorySearchItem *)item {
+    switch (item.kind) {
+        case WKChannelHistorySearchItemKindMessage:
+            [self locateMessageItem:item];
+            return;
+        case WKChannelHistorySearchItemKindMedia:
+            [self openMediaItem:item];
+            return;
+        case WKChannelHistorySearchItemKindFile:
+            [self openFileItem:item];
+            return;
+    }
+}
+
+- (void)locateMessageItem:(WKChannelHistorySearchItem *)item {
+    if (!item.canLocate) {
+        [self.view showMsg:LLang(@"无法定位到该消息")];
+        return;
+    }
+    NSString *cid = item.channelId.length > 0 ? item.channelId : self.channel.channelId;
+    NSInteger ct = item.channelType > 0 ? item.channelType : self.channel.channelType;
+    [self.searchInput resignFirstResponder];
+    [WKConversationRouter openChannelId:cid channelType:ct messageSeq:(uint32_t)item.messageSeq];
+}
+
+- (void)openMediaItem:(WKChannelHistorySearchItem *)tapped {
+    // 视频无可播 URL (服务端字段缺失 + 本地 WKMessageDB 也没同步过): 直接跳会话页
+    // 定位到该消息, 让聊天气泡的 SDK 下载 + 播放链路接管。
+    // 服务端未来补齐 messages/_search_media 视频响应的 URL 字段后, 此分支自然不再命中,
+    // 用户会直接看到大图浏览器里播放视频, 无需改任何代码。
+    if (tapped.mediaKind == WKChannelHistorySearchMediaKindVideo
+        && ![WKChannelHistoryMediaBrowser isVideoItemPlayable:tapped]
+        && tapped.canLocate) {
+        [self locateMessageItem:tapped];
+        return;
+    }
+
+    // 浏览器内部按 dataSource 真实位置定位初始页, 这里只需把所有 media 项原样传过去。
+    NSMutableArray<WKChannelHistorySearchItem *> *mediaList = [NSMutableArray array];
+    for (WKChannelHistorySearchItem *it in self.vm.items) {
+        if (it.kind != WKChannelHistorySearchItemKindMedia) continue;
+        [mediaList addObject:it];
+    }
+    if (mediaList.count == 0) return;
+    [self.searchInput resignFirstResponder];
+    __weak typeof(self) ws = self;
+    [WKChannelHistoryMediaBrowser presentFromItems:mediaList
+                                         tappedItem:tapped
+                                           onLocate:^(WKChannelHistorySearchItem *item) {
+        [ws locateMessageItem:item];
+    }];
+}
+
+- (void)openFileItem:(WKChannelHistorySearchItem *)item {
+    NSString *url = item.fileDownloadUrl.length > 0 ? item.fileDownloadUrl : item.filePreviewUrl;
+    if (url.length == 0) {
+        [self.view showMsg:LLang(@"文件链接不可用")];
+        return;
+    }
+    [self.searchInput resignFirstResponder];
+    UIView *hudView = self.view;
+    [hudView showHUD:LLang(@"下载中…")];
+    __weak typeof(self) ws = self;
+    NSString *fileName = item.fileName;
+    WKChannelHistorySearchItem *capturedItem = item;
+    [WKChannelHistoryFileDownloader downloadRemoteUrl:url
+                                              fileName:fileName
+                                               onProgress:^(double progress) {
+        // 进度只在内部记录, HUD 保持 spinner 模式 — 与项目其它下载场景一致 (短文件
+        // 进度不显示, 大文件留待后续如果有需要再换 annular determinate 模式)。
+    }
+                                            onComplete:^(NSURL *localURL, NSError *error) {
+        __strong typeof(ws) ss = ws;
+        if (!ss) return;
+        [hudView hideHud];
+        if (error || !localURL) {
+            [ss.view showMsg:error.localizedDescription ?: LLang(@"文件下载失败")];
+            return;
+        }
+        WKChannelHistoryFilePreviewVC *vc = [[WKChannelHistoryFilePreviewVC alloc] initWithFileURL:localURL
+                                                                                              title:capturedItem.fileName];
+        vc.historyItem = capturedItem;
+        vc.onLocate = ^(WKChannelHistorySearchItem *it) {
+            [ss locateMessageItem:it];
+        };
+        [[WKNavigationManager shared] pushViewController:vc animated:YES];
+    }];
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVC.m
@@ -502,6 +502,9 @@
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         fmt = [NSDateFormatter new];
+        // 与 toApiDict 里的 formatter 对齐, 用 en_US_POSIX locale, 避免设备设佛历
+        // / 伊斯兰历时年份被按当地日历渲染 (PR #64 review Octo-Q P2)。
+        fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         fmt.dateFormat = @"yyyy/MM/dd";
     });
     NSString *s = start ? [fmt stringFromDate:start] : LLang(@"最早");

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVM.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVM.h
@@ -1,0 +1,78 @@
+//
+//  WKChannelHistorySearchVM.h
+//  WuKongBase
+//
+//  搜索逻辑（关键词 / tab / 筛选 / 分页 / 取消旧请求）。视图无关。
+//
+
+#import <Foundation/Foundation.h>
+#import "WKChannelHistorySearchModels.h"
+
+@class WKChannel;
+@class WKChannelHistorySearchVM;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol WKChannelHistorySearchVMDelegate <NSObject>
+
+/// 通用状态变化：items / loading / error / cursor 任意一项发生变化时调用。
+/// UI 负责按需 reload。
+- (void)channelHistorySearchVMDidChangeState:(WKChannelHistorySearchVM *)vm;
+
+@optional
+/// 关键词超过 64 runes，已被截断。UI 弹一次 toast 提示。
+- (void)channelHistorySearchVMKeywordExceedLimit:(WKChannelHistorySearchVM *)vm;
+
+@end
+
+@interface WKChannelHistorySearchVM : NSObject
+
+- (instancetype)initWithChannel:(WKChannel *)channel;
+
+@property (nonatomic, weak, nullable) id<WKChannelHistorySearchVMDelegate> delegate;
+@property (nonatomic, strong, readonly) WKChannel *channel;
+
+@property (nonatomic, assign, readonly) WKChannelHistorySearchTab tab;
+@property (nonatomic, copy, readonly) NSString *keyword;
+@property (nonatomic, copy, readonly) WKChannelHistorySearchFilter *filter;
+
+@property (nonatomic, copy, readonly) NSArray<WKChannelHistorySearchItem *> *items;
+@property (nonatomic, assign, readonly) BOOL hasMore;
+@property (nonatomic, copy, readonly, nullable) NSString *nextCursor;
+
+@property (nonatomic, assign, readonly) BOOL isLoadingFirstPage;
+@property (nonatomic, assign, readonly) BOOL isLoadingNextPage;
+
+@property (nonatomic, copy, readonly, nullable) NSError *firstPageError;
+@property (nonatomic, copy, readonly, nullable) NSError *nextPageError;
+
+/// 是否有过一次"已发起请求"的搜索（用于区分 emptyHint vs noResults）。
+@property (nonatomic, assign, readonly) BOOL queryStarted;
+
+/// 当前 keyword/filter 组合是否允许发请求（与 web shouldRunSearch 一致）。
+@property (nonatomic, assign, readonly) BOOL shouldRunSearch;
+
+#pragma mark 用户操作入口
+
+/// 切换 tab：自动 reset cursor + 触发首屏拉取（若 shouldRunSearch）。
+- (void)setTab:(WKChannelHistorySearchTab)tab;
+
+/// 应用 keyword（含 64 runes 截断 + 超限通知 delegate）。
+/// 不做防抖 — UI 层先用 perform 防抖再调本方法。
+- (void)applyKeyword:(nullable NSString *)keyword;
+
+/// 应用筛选条件。会触发一次首屏刷新。
+- (void)applyFilter:(nullable WKChannelHistorySearchFilter *)filter;
+
+/// 首屏刷新（reset cursor）。
+- (void)refresh;
+
+/// 加载下一页。无 nextCursor 或 hasMore == NO 时直接返回。
+- (void)loadMore;
+
+/// 取消所有飞行中请求（页面离开时调用）。
+- (void)cancelInFlight;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVM.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/ChannelHistorySearch/WKChannelHistorySearchVM.m
@@ -1,0 +1,220 @@
+//
+//  WKChannelHistorySearchVM.m
+//
+
+#import "WKChannelHistorySearchVM.h"
+#import "WKChannelHistorySearchAPI.h"
+#import "WKChannelHistorySearchKeywordUtil.h"
+#import <WuKongIMSDK/WuKongIMSDK.h>
+
+@interface WKChannelHistorySearchVM ()
+@property (nonatomic, strong, readwrite) WKChannel *channel;
+
+@property (nonatomic, assign, readwrite) WKChannelHistorySearchTab tab;
+@property (nonatomic, copy, readwrite) NSString *keyword;
+@property (nonatomic, copy, readwrite) WKChannelHistorySearchFilter *filter;
+
+@property (nonatomic, copy, readwrite) NSArray<WKChannelHistorySearchItem *> *items;
+@property (nonatomic, assign, readwrite) BOOL hasMore;
+@property (nonatomic, copy, readwrite, nullable) NSString *nextCursor;
+
+@property (nonatomic, assign, readwrite) BOOL isLoadingFirstPage;
+@property (nonatomic, assign, readwrite) BOOL isLoadingNextPage;
+@property (nonatomic, copy, readwrite, nullable) NSError *firstPageError;
+@property (nonatomic, copy, readwrite, nullable) NSError *nextPageError;
+@property (nonatomic, assign, readwrite) BOOL queryStarted;
+
+/// 单调递增请求号。每次发起请求都自增；回包到达后比对，过期回包丢弃。
+/// 这种方案比 NSURLSessionDataTask cancel 简单 — 不需要存 task 引用，也能避免乱序覆盖。
+@property (nonatomic, assign) NSInteger reqIdCounter;
+/// 当前首屏请求的 reqId（0 表示无活跃首屏请求）。
+@property (nonatomic, assign) NSInteger firstPageReqId;
+/// 当前下一页请求的 reqId。
+@property (nonatomic, assign) NSInteger nextPageReqId;
+
+@end
+
+@implementation WKChannelHistorySearchVM
+
+- (instancetype)initWithChannel:(WKChannel *)channel {
+    self = [super init];
+    if (self) {
+        _channel = channel;
+        _tab = WKChannelHistorySearchTabAll;
+        _keyword = @"";
+        _filter = [WKChannelHistorySearchFilter new];
+        _items = @[];
+        _hasMore = NO;
+        _nextCursor = nil;
+        _isLoadingFirstPage = NO;
+        _isLoadingNextPage = NO;
+        _queryStarted = NO;
+    }
+    return self;
+}
+
+#pragma mark - Public
+
+- (BOOL)shouldRunSearch {
+    return [WKChannelHistorySearchAPI shouldRunSearchForTab:self.tab
+                                                     keyword:self.keyword
+                                                   hasFilter:self.filter.hasEffectiveFilters];
+}
+
+- (void)setTab:(WKChannelHistorySearchTab)tab {
+    if (_tab == tab) return;
+    _tab = tab;
+    [self refresh];
+}
+
+- (void)applyKeyword:(NSString *)keyword {
+    BOOL truncated = NO;
+    NSString *cleaned = [WKChannelHistorySearchKeywordUtil truncateToDefault:keyword ?: @""
+                                                                  didTruncate:&truncated];
+    if ([cleaned isEqualToString:self.keyword]) {
+        if (truncated) {
+            if ([self.delegate respondsToSelector:@selector(channelHistorySearchVMKeywordExceedLimit:)]) {
+                [self.delegate channelHistorySearchVMKeywordExceedLimit:self];
+            }
+        }
+        return;
+    }
+    self.keyword = cleaned;
+    if (truncated) {
+        if ([self.delegate respondsToSelector:@selector(channelHistorySearchVMKeywordExceedLimit:)]) {
+            [self.delegate channelHistorySearchVMKeywordExceedLimit:self];
+        }
+    }
+    [self refresh];
+}
+
+- (void)applyFilter:(WKChannelHistorySearchFilter *)filter {
+    self.filter = filter ? [filter copy] : [WKChannelHistorySearchFilter new];
+    [self refresh];
+}
+
+- (void)refresh {
+    [self cancelInFlight];
+    self.items = @[];
+    self.hasMore = NO;
+    self.nextCursor = nil;
+    self.firstPageError = nil;
+    self.nextPageError = nil;
+
+    if (![self shouldRunSearch]) {
+        self.isLoadingFirstPage = NO;
+        self.queryStarted = NO;
+        [self notifyState];
+        return;
+    }
+
+    self.queryStarted = YES;
+    self.isLoadingFirstPage = YES;
+    [self notifyState];
+
+    self.reqIdCounter += 1;
+    NSInteger reqId = self.reqIdCounter;
+    self.firstPageReqId = reqId;
+
+    __weak typeof(self) ws = self;
+    [WKChannelHistorySearchAPI searchWithTab:self.tab
+                                      channel:self.channel
+                                      keyword:self.keyword
+                                       filter:self.filter
+                                       cursor:nil
+                                     pageSize:WKChannelHistorySearchDefaultPageSize]
+        .then(^(WKChannelHistorySearchPage *page) {
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            if (ss.firstPageReqId != reqId) return; // 过期
+            ss.firstPageReqId = 0;
+            ss.isLoadingFirstPage = NO;
+            ss.items = page.items ?: @[];
+            ss.hasMore = page.hasMore;
+            ss.nextCursor = page.nextCursor;
+            ss.firstPageError = nil;
+            [ss notifyState];
+        })
+        .catch(^(NSError *error) {
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            if (ss.firstPageReqId != reqId) return;
+            ss.firstPageReqId = 0;
+            ss.isLoadingFirstPage = NO;
+            ss.firstPageError = error;
+            [ss notifyState];
+        });
+}
+
+- (void)loadMore {
+    if (self.isLoadingNextPage) return;
+    if (!self.hasMore) return;
+    if (self.nextCursor.length == 0) return; // 与 web 同款守卫：无 cursor 视为终止
+    if (self.isLoadingFirstPage) return;
+
+    self.isLoadingNextPage = YES;
+    self.nextPageError = nil;
+    [self notifyState];
+
+    self.reqIdCounter += 1;
+    NSInteger reqId = self.reqIdCounter;
+    self.nextPageReqId = reqId;
+    NSString *cursor = self.nextCursor;
+
+    __weak typeof(self) ws = self;
+    [WKChannelHistorySearchAPI searchWithTab:self.tab
+                                      channel:self.channel
+                                      keyword:self.keyword
+                                       filter:self.filter
+                                       cursor:cursor
+                                     pageSize:WKChannelHistorySearchDefaultPageSize]
+        .then(^(WKChannelHistorySearchPage *page) {
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            if (ss.nextPageReqId != reqId) return;
+            ss.nextPageReqId = 0;
+            ss.isLoadingNextPage = NO;
+            // 守卫：next_cursor 不变 / 相同 → 视为终止，避免死循环（与 web 同口径）
+            BOOL sameCursor = (page.nextCursor.length > 0) && [page.nextCursor isEqualToString:cursor];
+            NSArray *appended = page.items ?: @[];
+            if (appended.count > 0) {
+                ss.items = [ss.items arrayByAddingObjectsFromArray:appended];
+            }
+            if (sameCursor) {
+                ss.hasMore = NO;
+                ss.nextCursor = nil;
+            } else {
+                ss.hasMore = page.hasMore;
+                ss.nextCursor = page.nextCursor;
+            }
+            ss.nextPageError = nil;
+            [ss notifyState];
+        })
+        .catch(^(NSError *error) {
+            __strong typeof(ws) ss = ws;
+            if (!ss) return;
+            if (ss.nextPageReqId != reqId) return;
+            ss.nextPageReqId = 0;
+            ss.isLoadingNextPage = NO;
+            ss.nextPageError = error;
+            [ss notifyState];
+        });
+}
+
+- (void)cancelInFlight {
+    // 通过推进 reqId 让所有飞行回包过期。底层 task 仍会跑完但回调被丢弃。
+    self.firstPageReqId = 0;
+    self.nextPageReqId = 0;
+    self.isLoadingFirstPage = NO;
+    self.isLoadingNextPage = NO;
+}
+
+#pragma mark - Helpers
+
+- (void)notifyState {
+    if ([self.delegate respondsToSelector:@selector(channelHistorySearchVMDidChangeState:)]) {
+        [self.delegate channelHistorySearchVMDidChangeState:self];
+    }
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/WKConversationSettingVM.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationSetting/WKConversationSettingVM.m
@@ -20,6 +20,7 @@
 #import "WKTableSectionUtil.h"
 #import "WKGroupQRCodeVC.h"
 #import "WKGlobalSearchResultController.h"
+#import "WKChannelHistorySearchVC.h"
 #import "WKThreadListVC.h"
 #import "WKThreadService.h"
 #import "WKGroupMdVC.h"
@@ -457,9 +458,12 @@
                     @"showBottomLine":@(NO),
                     @"showTopLine":@(NO),
                     @"onClick":^{
-                        WKGlobalSearchResultController *vc = [WKGlobalSearchResultController new];
+                        // 入口：进入新版「查找聊天内容」页（与 web ChannelSearchPanel 同口径，纯 API）。
+                        // 不再走全局搜索栈 WKGlobalSearchResultController —— 那条路径仍服务
+                        // 「会话列表→搜索→在某频道点更多」次级跳转，独立保留。
+                        WKChannelHistorySearchVC *vc = [WKChannelHistorySearchVC new];
                         vc.channel = weakSelf.channel;
-                        [[WKNavigationManager shared] pushViewController:vc animated:NO];
+                        [[WKNavigationManager shared] pushViewController:vc animated:YES];
                     }
                 }
             ]

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKMessageTextView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKMessageTextView.m
@@ -57,6 +57,22 @@ static void *kWKMTVTokens = &kWKMTVTokens;
 /// UITextView 的 NSLayoutManager 会遵守段落样式的 lineBreakMode，
 /// 导致 markdown (cmark-gfm) 渲染出的 TruncatingTail 段落被截断。
 /// 重写 setAttributedText: 将所有段落样式归一化为 WordWrapping。
+///
+/// ⚠ 不要在 setter 内部调 `[super setText:nil]` 试图集中清 textStorage:
+/// UITextView 的 -setText: 内部会走 self.attributedText 路径再次进入本 setter,
+/// 形成无穷递归 → 打开任意聊天页直接闪退 (iOS 26 已实测)。
+/// "先 .text=nil 再 .attributedText=X" 的两步清空模式必须由调用点显式做 (例如
+/// WKTextMessageCell.m:3380 选区高亮路径), setter 只负责段落归一化 + 调 super,
+/// 不替调用方代劳, 避免互调死循环。
+///
+/// ⚠ 不要在 setter 内部同步 `ensureLayoutForTextContainer:`:
+/// setter 是所有写入必经入口 (refresh: 主路径 / measure / selection / segmented
+/// 重建), 每次都强制同步 glyph 生成会把「主线程 heightForRow 30 条消息 × 60-80ms
+/// parseAttr」的时间雪上加霜, 低性能机 (CPU 频率低) 累加数秒触发 UI 卡死。
+/// 需要 ensureLayout 的调用方 (+measureTextViewSize:) 已经自己调, display 路径
+/// 由 UIKit layoutSubviews 自然触发 —— setter 不必代劳。
+/// 若真出现「setAttrText 之后首帧空白」的具体 case, 在那一处调用点单独补
+/// ensureLayout, 不再放回 setter 里做全局代劳。
 - (void)setAttributedText:(NSAttributedString *)attributedText {
     if (!attributedText || attributedText.length == 0) {
         [super setAttributedText:attributedText];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKSafeFilePreviewVC.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKSafeFilePreviewVC.h
@@ -4,6 +4,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WKSafeFilePreviewVC : WKBaseVC
 
+/// 当前预览的本地文件 URL (子类可用)。
+@property (nonatomic, strong, readonly) NSURL *fileURL;
+/// 当前预览的标题 (子类可用)。
+@property (nonatomic, copy, readonly, nullable) NSString *fileTitle;
+
 - (instancetype)initWithFileURL:(NSURL *)fileURL title:(nullable NSString *)title;
 
 + (void)showFilePreview:(NSURL *)fileURL title:(NSString *)title;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKSafeFilePreviewVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKSafeFilePreviewVC.m
@@ -1,6 +1,7 @@
 #import "WKSafeFilePreviewVC.h"
 #import <PDFKit/PDFKit.h>
 #import <WebKit/WebKit.h>
+#import <QuickLook/QuickLook.h>
 #import <AVKit/AVKit.h>
 #import <AVFoundation/AVFoundation.h>
 #import "WKApp.h"
@@ -14,12 +15,13 @@
 static UIWindow *_previewWindow = nil;
 static UIWindow *_previousKeyWindow = nil;
 
-@interface WKSafeFilePreviewVC ()<WKNavigationDelegate>
+@interface WKSafeFilePreviewVC ()<WKNavigationDelegate, QLPreviewControllerDataSource, QLPreviewControllerDelegate>
 @property (nonatomic, strong) NSURL *fileURL;
 @property (nonatomic, copy) NSString *fileTitle;
 @property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, strong) UIActivityIndicatorView *loadingIndicator;
 @property (nonatomic, strong) AVPlayerViewController *playerVC; // mp4/mov 等视频走 AVPlayer
+@property (nonatomic, strong) QLPreviewController *qlController; // xls/xlsx 走 QuickLook, 见 setupQuickLookInFrame:
 @end
 
 @implementation WKSafeFilePreviewVC
@@ -84,8 +86,7 @@ static UIWindow *_previousKeyWindow = nil;
 + (void)dismissPreview {
     if (!_previewWindow) return;
 
-    // 清理 WebKit + AVPlayer (video 路径不走 webView, 需要单独 teardown 否则
-    // 关窗后 player 还在内存里继续放音)。
+    // 清理 WebKit + AVPlayer + QuickLook (三条渲染路径都独立占资源, 关窗前需分别 teardown)。
     UINavigationController *nav = (UINavigationController *)_previewWindow.rootViewController;
     if ([nav isKindOfClass:[UINavigationController class]]) {
         WKSafeFilePreviewVC *vc = (WKSafeFilePreviewVC *)nav.topViewController;
@@ -96,6 +97,7 @@ static UIWindow *_previousKeyWindow = nil;
                 vc.webView = nil;
             }
             [vc teardownPlayer];
+            [vc teardownQuickLook];
         }
     }
 
@@ -139,6 +141,15 @@ static UIWindow *_previousKeyWindow = nil;
         [self setupPDFViewInFrame:contentFrame];
     } else if ([WKSafeFilePreviewVC mediaExtensions:ext]) {
         [self setupMediaPlayerInFrame:contentFrame];
+    } else if ([ext isEqualToString:@"xls"] || [ext isEqualToString:@"xlsx"]) {
+        // Excel: WebKit loadFileURL 对 xlsx 走内置 QuickLook 插件, 渲染在 native 层而非 DOM,
+        // WKUserScript / evaluateJavaScript 都触达不到 —— 深色下容器 bg 是 #1c1c1e、内容
+        // 层字色仍是纯黑, 结果就是"黑字-黑底"看不清 (用户初次报的问题)。
+        // 换成 QLPreviewController 后由系统 QuickLook 直接渲染, 与 Files.app 一致:
+        // 内容层始终按原文档配色 (白底 + 用户自设的单元格 fg/bg + 条件格式颜色),
+        // 不做主题反色 —— 强行反色会破坏 xlsx 里"红色警戒行 / 蓝色标题" 之类的用户语义。
+        // 见 -setupQuickLookInFrame:。
+        [self setupQuickLookInFrame:contentFrame];
     } else {
         [self setupWebViewInFrame:contentFrame];
     }
@@ -189,6 +200,7 @@ static UIWindow *_previousKeyWindow = nil;
         [self.webView removeFromSuperview];
         self.webView = nil;
         [self teardownPlayer];
+        [self teardownQuickLook];
         [self.navigationController popViewControllerAnimated:YES];
     } else {
         [WKSafeFilePreviewVC dismissPreview];
@@ -325,6 +337,60 @@ static UIWindow *_previousKeyWindow = nil;
     pdfView.backgroundColor = bgColor;
     pdfView.document = [[PDFDocument alloc] initWithURL:self.fileURL];
     [self.view addSubview:pdfView];
+}
+
+#pragma mark - Excel (QLPreviewController - QuickLook)
+
+// xls / xlsx 单独走 QuickLook, 不走 WKWebView loadFileURL。
+//
+// 背景: WebKit 对 xlsx 的渲染委托给内置 Office 插件, 内容画在 native 层而非 DOM,
+// host 侧的 WKUserScript / evaluateJavaScript 都改不到样式; 而 WKWebView 容器 bg
+// 在深色下是 #1c1c1e, 插件层还按纯黑字画 → "黑字-黑底"看不清。
+//
+// 主题策略: **不对内容做深色主题化**。
+//   - QLPreviewController 是 iOS 系统 QuickLook 的官方入口, 与 Files.app / Numbers
+//     行为一致 —— 内容层永远按原文档配色画 (白底 + 用户自设的字色/单元格 bg /
+//     条件格式着色)。
+//   - 强行反色 / 覆盖字色会破坏 xlsx 里"红色警戒行 / 蓝色标题 / 黄底提示单元格"
+//     之类的用户语义, 得不偿失。
+//   - QLPreviewController.overrideUserInterfaceStyle 对 xlsx 内容层是 no-op (试过 .dark
+//     无效, 内容仍白底), 我们锁到 .light 是为了让 QL 自己的 chrome (Loading 转圈 / 提示)
+//     与白色内容岛保持一致, 避免"暗底浮层-白色内容"的割裂感。外层 WKNavigationBar
+//     仍随 app style 走深色。
+//
+// 布局: QL 作为子 VC add 进内容区, 不 push, 所以不会画自己的 top toolbar,
+// 外层 WKNavigationBar 的 title/back/share 保持可用。
+- (void)setupQuickLookInFrame:(CGRect)frame {
+    QLPreviewController *ql = [[QLPreviewController alloc] init];
+    ql.dataSource = self;
+    ql.delegate = self;
+    if (@available(iOS 13.0, *)) {
+        ql.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
+    [self addChildViewController:ql];
+    ql.view.frame = frame;
+    ql.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:ql.view];
+    [ql didMoveToParentViewController:self];
+    self.qlController = ql;
+}
+
+- (void)teardownQuickLook {
+    if (!self.qlController) return;
+    [self.qlController willMoveToParentViewController:nil];
+    [self.qlController.view removeFromSuperview];
+    [self.qlController removeFromParentViewController];
+    self.qlController = nil;
+}
+
+#pragma mark - QLPreviewControllerDataSource
+
+- (NSInteger)numberOfPreviewItemsInPreviewController:(QLPreviewController *)controller {
+    return self.fileURL ? 1 : 0;
+}
+
+- (id<QLPreviewItem>)previewController:(QLPreviewController *)controller previewItemAtIndex:(NSInteger)index {
+    return self.fileURL;
 }
 
 #pragma mark - 视频 / 音频 (AVPlayerViewController)

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
@@ -1481,10 +1481,15 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
         key = [NSString stringWithFormat:@"%@-size-edit-%lu",model.clientMsgNo,model.remoteExtra.editedAt];
     }
     static WKMemoryCache *memoryCache;
-    if(!memoryCache) {
+    // Bugly #9089: 老 `if(!memoryCache) alloc` 写法在首次进群 bg 预算高度 +
+    // 主线程 heightForRow 同帧并发时能各起一份实例, 先写者被 ARC storeStrong
+    // 立刻释放, 遗留引用在后续 getCache: 释放阶段命中 objc_release_x0 SEGV。
+    // dispatch_once 保证唯一实例, 与 textAttrCache/segHeightCache 对齐。
+    static dispatch_once_t sizeCacheOnce;
+    dispatch_once(&sizeCacheOnce, ^{
         memoryCache = [[WKMemoryCache alloc] init];
         memoryCache.maxCacheNum = 0; // 数值缓存，内存极小，不设上限
-    }
+    });
     NSString  *sizeStr =  [memoryCache getCache:key];
     if(sizeStr) {
         return CGSizeFromString(sizeStr);
@@ -1535,10 +1540,12 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
         key = [NSString stringWithFormat:@"%@-lastLine-edit-%lu",model.clientMsgNo,model.remoteExtra.editedAt];
     }
     static WKMemoryCache *memoryCache;
-    if(!memoryCache) {
+    // 见 textSize: 里的 Bugly #9089 注释, 同样用 dispatch_once 保护并发首建。
+    static dispatch_once_t lastLineCacheOnce;
+    dispatch_once(&lastLineCacheOnce, ^{
         memoryCache = [[WKMemoryCache alloc] init];
         memoryCache.maxCacheNum = 0; // 数值缓存，内存极小，不设上限
-    }
+    });
     NSNumber  *lastLineWidth =  [memoryCache getCache:key];
     if(lastLineWidth) {
         return lastLineWidth.floatValue;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
@@ -1864,8 +1864,10 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
     }
 
     } @catch (NSException *exception) {
+#if DEBUG
         NSLog(@"[CellRefresh] ⚠️ refresh 抛异常被隔离 msgNo=%@ name=%@ reason=%@",
               model.clientMsgNo, exception.name, exception.reason);
+#endif
         [self wk_renderPlainTextFallback:model];
     }
 }
@@ -1896,7 +1898,9 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
                                         context:nil].size;
         self.textLbl.lim_size = CGSizeMake(ceil(fit.width), ceil(fit.height));
     } @catch (NSException *e) {
+#if DEBUG
         NSLog(@"[CellRefresh] ⚠️ fallback 也抛异常, 留空气泡: %@", e.reason);
+#endif
     }
 }
 
@@ -2209,8 +2213,10 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
     }
 
     } @catch (NSException *exception) {
+#if DEBUG
         NSLog(@"[CellLayout] ⚠️ layoutSubviews 抛异常被隔离 msgNo=%@ name=%@ reason=%@",
               self.messageModel.clientMsgNo, exception.name, exception.reason);
+#endif
     }
 }
 
@@ -2651,8 +2657,10 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
     if (tableHTML.length > 0) {
         [webView loadHTMLString:tableHTML baseURL:nil];
     }
+#if DEBUG
     NSLog(@"[WKWebView] content process terminated, reloaded msgNo=%@ idx=%lu",
           self.messageModel.clientMsgNo, (unsigned long)idx);
+#endif
 }
 
 -(void) scrollViewDidScroll:(UIScrollView *)scrollView {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
@@ -56,6 +56,14 @@
 #define kBotActionTopSpace 10.0f
 #define kBotActionBtnSpacing 10.0f
 
+// 私有 category: 让本 cell 可以在 WebView JS 高度回调里同步失效 WKMessageListView
+// 的 cellHeightCache 条目, 避免只清 segHeightCache 但 UITableView 命中 stale cellHeightCache
+// 直接 return 旧公式估算高度 (Bug 1「表格气泡高度错」根因)。
+// helper 实现在 WKMessageListView.m 的 wk_invalidateHeightCacheForMessage:。
+@interface WKMessageListView (WKTextCellHeightInvalidation)
+- (void)wk_invalidateHeightCacheForMessage:(WKMessageModel*)msg;
+@end
+
 @interface WKTextMessageCell ()<CNContactViewControllerDelegate,CNContactPickerDelegate,WKNavigationDelegate,UIScrollViewDelegate,UITextViewDelegate,UIGestureRecognizerDelegate>
 
 @property(nonatomic,strong) WKMessageTextView *textLbl; // 原 UILabel，改为 UITextView 子类，天然支持文字选择
@@ -298,6 +306,14 @@ static NSMutableDictionary *_jsTableHeights;
 // "先清后写" 的两步模式, 无需在 setter 内代劳 (那样会引发 UITextView setter
 // 互调死循环, 见 WKMessageTextView.m 类注释)。
 //
+// ⚠ 只清「非分段」cell 的 textLbl: 分段 cell (hasTable, segmentsBuilt=YES) 用
+// 唯一 reuseIdentifier 永远只给同一条 msgId 用, refresh: 的 hasTable && segmentsBuilt
+// 分支会 SKIP textLbl 重设 (line 1601, 假设 textLbl 里已经有正确的第一段文本)。
+// 如果这里无条件清空, 下次同一 cell 出列再展示时 textLbl 是空的 → 表格前的
+// 文字消失, 但 lim_size 早算好了所以气泡高度不缩 → 用户看到「气泡高但半空」。
+// 非分段 cell (进普通 reuse pool) 才有跨消息复用风险, 需要清; 分段 cell 生命
+// 周期跟 msgId 绑定, 内容不需要清。
+//
 // ⚠ 不调 self.textLbl.text = nil: UITextView -setText: 内部走 self.attributedText
 // 路径会再次进入子类 setter, 与 setter 的清零逻辑互调死递归 (iOS 26 实测闪退)。
 // 单调 .attributedText=nil 即可清空 textStorage, 不会触发互调。
@@ -305,7 +321,9 @@ static NSMutableDictionary *_jsTableHeights;
     if ([self wk_isInSelectionMode]) {
         [self endInBubbleTextSelection];
     }
-    self.textLbl.attributedText = nil;
+    if (!self.segmentsBuilt) {
+        self.textLbl.attributedText = nil;
+    }
     [super prepareForReuse];
 }
 
@@ -2570,6 +2588,25 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
             NSString *modeTag = ([WKApp shared].config.style == WKSystemStyleDark) ? @"d" : @"l";
             NSString *cacheKey = [NSString stringWithFormat:@"%@-segH-%@", self.messageModel.clientMsgNo, modeTag];
             [[[self class] segHeightCache] setCache:nil forKey:cacheKey];
+
+            // 关键: 同步失效上层 cellHeightCache 里同 msg 的整条 cell 高度。
+            // 只清 segHeightCache 不够 —— UITableView 下次问高度时 heightForRow
+            // 会先命中 cellHeightCache 拿到基于公式估算的旧值直接 return, 根本
+            // 不会走 sizeForMessage → segmentedContentHeightForMessage → 读 segHeightCache
+            // 的新 JS 高度。结果: 表格气泡高度永远卡在公式估算, JS 实测被忽略,
+            // 就是 Bug 1「表格气泡高度错」的经典触发面 (概率性: 复用 cell 时才命中)。
+            // 找到 tableView 前主动清 cellHeightCache 里对应 msg 的条目 (bubblePos +
+            // 可能的 edit 变体), 然后 begin/endUpdates 会正常走 measure 拿新高度。
+            UIView *_hostView = self.superview;
+            while (_hostView && ![_hostView isKindOfClass:[UITableView class]]) _hostView = _hostView.superview;
+            if ([_hostView isKindOfClass:[UITableView class]]) {
+                UITableView *_hostTv = (UITableView *)_hostView;
+                UIView *_hv = _hostTv.superview;
+                while (_hv && ![_hv isKindOfClass:[WKMessageListView class]]) _hv = _hv.superview;
+                if ([_hv isKindOfClass:[WKMessageListView class]]) {
+                    [(WKMessageListView*)_hv wk_invalidateHeightCacheForMessage:self.messageModel];
+                }
+            }
 
             // 触发 UITableView 重新计算 cell 高度
             UIView *v = self.superview;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Messages/WKTextMessageCell.m
@@ -290,10 +290,22 @@ static NSMutableDictionary *_jsTableHeights;
 // 另一条消息时，旧的句柄/window tap/KVO/timer/通知 会泄漏到新消息上。在这里
 // 兜底退出选区。表格 cell 用唯一 reuseIdentifier 不会被复用，但调一下 end 也
 // 是无害的。
+//
+// reuse 兜底: cell 出列瞬间主动清空 textLbl.attributedText, 挡住 "cell 已被绘制
+// 到屏幕、但本轮 refresh: 还没跑完" 的中间态。之前 "刷会话时旧消息文字 + 新消息
+// 文字叠在同一气泡" 的反复回归 (094e713 / 9890f1b / 4288435 / c89d436) 全是这一族。
+// 与 willDisplay→refresh: 之间隔了一个 runloop tick, 两步天然分离, 等同于显式
+// "先清后写" 的两步模式, 无需在 setter 内代劳 (那样会引发 UITextView setter
+// 互调死循环, 见 WKMessageTextView.m 类注释)。
+//
+// ⚠ 不调 self.textLbl.text = nil: UITextView -setText: 内部走 self.attributedText
+// 路径会再次进入子类 setter, 与 setter 的清零逻辑互调死递归 (iOS 26 实测闪退)。
+// 单调 .attributedText=nil 即可清空 textStorage, 不会触发互调。
 -(void) prepareForReuse {
     if ([self wk_isInSelectionMode]) {
         [self endInBubbleTextSelection];
     }
+    self.textLbl.attributedText = nil;
     [super prepareForReuse];
 }
 
@@ -1528,6 +1540,14 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
 - (void)refresh:(WKMessageModel *)model {
     [super refresh:model];
 
+    // 故障隔离: refresh 主体路径里 attrStr 解析 / markdown 渲染 / 表格段构建 /
+    // WKWebView 装载 / reply 块拼装 任意一处抛 NSException, 整条主线程的 batch
+    // update 流程会被打断, 同帧其它 cell 的 layoutSubviews 全部跳过 — 视觉上
+    // 就是"整页气泡全没了, 必须退出重进才能恢复"。这条共因链路是用户反馈
+    // "刷会话气泡全空"的根本原因之一 (见 8141a16 commit message + 同期排查)。
+    // 这里把单条 cell 的渲染异常隔离在本 cell 内, 降级为纯文本气泡兜底, 让
+    // 同帧其它 cell 的 layout 不被波及。
+    @try {
     // 检测链接卡片
     NSString *rawText = [[self class] getRawContent:model];
     if ([rawText hasPrefix:@"[链接]"]) {
@@ -1818,6 +1838,41 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
         self.botActionView.hidden = YES;
     }
 
+    } @catch (NSException *exception) {
+        NSLog(@"[CellRefresh] ⚠️ refresh 抛异常被隔离 msgNo=%@ name=%@ reason=%@",
+              model.clientMsgNo, exception.name, exception.reason);
+        [self wk_renderPlainTextFallback:model];
+    }
+}
+
+// 异常隔离降级路径: refresh 主体任一处抛异常时, 兜底渲染成"纯文本气泡 + 默认配色"。
+// 不调用任何 markdown / 表格 / 段落构建路径 — 这条路径必须比 refresh 主体短小且
+// 不再抛异常, 否则故障隔离就成了故障传染。包一层 @try 兜底, 自己再炸就只剩空气泡,
+// 但仍不会污染整页 layout。
+- (void)wk_renderPlainTextFallback:(WKMessageModel *)model {
+    @try {
+        [self clearSegmentViews];
+        self.linkCardView.hidden = YES;
+        self.isLinkCard = NO;
+        self.textLbl.hidden = NO;
+        NSString *raw = [[self class] getRawContent:model] ?: @"";
+        UIColor *color = model.isSend ? [WKApp shared].config.messageSendTextColor : [WKApp shared].config.messageRecvTextColor;
+        if (!color) color = [UIColor blackColor];
+        NSDictionary *attrs = @{
+            NSFontAttributeName: [UIFont systemFontOfSize:16.0f],
+            NSForegroundColorAttributeName: color,
+        };
+        NSAttributedString *attr = [[NSAttributedString alloc] initWithString:raw attributes:attrs];
+        self.textLbl.attributedText = attr;
+        CGFloat maxWidth = [WKApp shared].config.messageContentMaxWidth;
+        if (maxWidth <= 0) maxWidth = 240.0f;
+        CGSize fit = [attr boundingRectWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX)
+                                        options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
+                                        context:nil].size;
+        self.textLbl.lim_size = CGSizeMake(ceil(fit.width), ceil(fit.height));
+    } @catch (NSException *e) {
+        NSLog(@"[CellRefresh] ⚠️ fallback 也抛异常, 留空气泡: %@", e.reason);
+    }
 }
 
 -(void) onTapWithGestureRecognizer:(TapLongTapOrDoubleTapGestureRecognizerWrap*)gesture {
@@ -1937,6 +1992,12 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
         return;
     }
 
+    // 故障隔离: layout 主体异常 (reply 块尺寸算崩 / segment frame 数学 NaN /
+    // WKWebView 容器 frame 越界等) 沿 layoutSubviews 抛进 UIKit batch update,
+    // 会打断同帧后续所有 cell 的 layout - 视觉上"整页气泡全没"。这里把单 cell
+    // layout 异常隔离, [super layoutSubviews] 已经跑完, 基础 frame 已就位,
+    // 我们只是放弃本帧的子视图精细布局, 下一帧 UIKit 自然重试。
+    @try {
     CGFloat replyBoxBottom = 0.0f;
     
     if([[self class] hasReply:self.messageModel]) {
@@ -2122,6 +2183,10 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
         }];
     }
 
+    } @catch (NSException *exception) {
+        NSLog(@"[CellLayout] ⚠️ layoutSubviews 抛异常被隔离 msgNo=%@ name=%@ reason=%@",
+              self.messageModel.clientMsgNo, exception.name, exception.reason);
+    }
 }
 
 -(void) layoutName {
@@ -2516,6 +2581,34 @@ static WKWebViewConfiguration *_sharedWebViewConfig;
             }
         });
     }];
+}
+
+// WKWebView content process 被 iOS 回收后的自愈路径。
+//
+// 触发场景: 设备长时间锁屏 / 整机内存压力大 / 系统主动回收 WebContent XPC,
+// WKWebView 实例还活着但底层 process 已死, 表格段视觉上变成空白容器,
+// evaluateJavaScript / loadHTMLString 调进去都没反应 — 这条 cell 看起来
+// "好像正常但表格永远不出来", 是用户反馈"回前台后部分气泡空白" 的另一条根因。
+//
+// 自愈: tableRawContents 在 segment 构建时存了原始 markdown 表格内容,
+// 这里用它直接重建 HTML 重新装载, 不需要走 refresh: 全量重建 (避免被
+// reload 视为漂移源)。装载触发 WebKit 重新 spawn WebContent process, 表格
+// 内容回来。idx 匹配失败时安全跳过, 不抛异常。
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    NSUInteger idx = [self.tableWebViews indexOfObject:webView];
+    if (idx == NSNotFound || idx >= self.tableRawContents.count) {
+        return;
+    }
+    NSString *content = self.tableRawContents[idx];
+    if (content.length == 0) return;
+    NSString *tableHTML = [WKMarkdownRenderer extractTableHTML:content
+                                                     fontSize:[WKApp shared].config.messageTextFontSize
+                                                 textColorHex:@"#333333"];
+    if (tableHTML.length > 0) {
+        [webView loadHTMLString:tableHTML baseURL:nil];
+    }
+    NSLog(@"[WKWebView] content process terminated, reloaded msgNo=%@ idx=%lu",
+          self.messageModel.clientMsgNo, (unsigned long)idx);
 }
 
 -(void) scrollViewDidScroll:(UIScrollView *)scrollView {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Thread/WKThreadSettingVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Thread/WKThreadSettingVC.m
@@ -20,6 +20,7 @@
 #import "WKChannelUtil.h"
 #import "WKRealnamePrefetcher.h"
 #import "WKInputVC.h"
+#import "WKChannelHistorySearchVC.h"
 
 @interface WKThreadSettingVC () <WKSettingMemberGridViewDelegate, UITableViewDataSource, UITableViewDelegate, WKChannelManagerDelegate>
 
@@ -312,7 +313,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (section == 0) return 2;
+    if (section == 0) return 3; // 子区名称 / GROUP.md / 查找聊天内容
     return 1;
 }
 
@@ -349,6 +350,17 @@
         cell.detailTextLabel.text = hasMd ? [NSString stringWithFormat:@"%@ v%ld", LLang(@"已配置"), (long)mdVersion] : LLang(@"未配置");
         cell.detailTextLabel.font = [[WKApp shared].config appFontOfSize:15.0f];
         cell.detailTextLabel.textColor = [UIColor grayColor];
+        cell.backgroundColor = [WKApp shared].config.cellBackgroundColor;
+        return cell;
+    } else if (indexPath.section == 0 && indexPath.row == 2) {
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SearchCell"];
+        if (!cell) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"SearchCell"];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        }
+        cell.textLabel.text = LLang(@"查找聊天内容");
+        cell.textLabel.font = [[WKApp shared].config appFontOfSize:16.0f];
+        cell.textLabel.textColor = [WKApp shared].config.defaultTextColor;
         cell.backgroundColor = [WKApp shared].config.cellBackgroundColor;
         return cell;
     } else {
@@ -390,6 +402,11 @@
         WKGroupMdVC *vc = [WKGroupMdVC new];
         vc.channel = self.channel;
         vc.canEdit = self.isCreator || self.isGroupAdmin;
+        [[WKNavigationManager shared] pushViewController:vc animated:YES];
+    } else if (indexPath.section == 0 && indexPath.row == 2) {
+        // 子区"查找聊天内容"入口 — 与群/私聊一致，进入新版搜索页（纯 API，对齐 web）。
+        WKChannelHistorySearchVC *vc = [WKChannelHistorySearchVC new];
+        vc.channel = self.channel;
         [[WKNavigationManager shared] pushViewController:vc animated:YES];
     } else if (indexPath.section == 1) {
         if (self.isCreator) {

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -2137,7 +2137,20 @@ static WKApp *_instance;
 
 -(AnyPromise*) loadCollectStickers {
     __weak typeof(self) weakSelf = self;
-   return [[WKAPIClient sharedClient] GET:@"sticker/user" parameters:nil model:WKSticker.class].then(^(NSArray *stickerArray) {
+   return [[WKAPIClient sharedClient] GET:@"sticker/user" parameters:nil model:WKSticker.class].then(^(id stickerResp) {
+        // Bugly: WKAPIClient.resultToModel: 对 NSDictionary 响应会返回单个 WKSticker*,
+        // 对 NSArray 响应才返回 NSArray<WKSticker*>*。sticker/user 通常返回数组,
+        // 但服务端异常帧 / 空态 / envelope 变体下会下发 dict, 直接 assign 到
+        // strong NSArray* 属性 (ObjC 无运行期强类型), 后续 collectStickers.count
+        // 触发 -[WKSticker count]: unrecognized selector 崩溃 (Bugly 上报)。
+        NSArray<WKSticker*> *stickerArray;
+        if ([stickerResp isKindOfClass:[NSArray class]]) {
+            stickerArray = (NSArray<WKSticker*>*)stickerResp;
+        } else if ([stickerResp isKindOfClass:[WKSticker class]]) {
+            stickerArray = @[(WKSticker*)stickerResp];
+        } else {
+            stickerArray = @[];
+        }
         weakSelf.collectStickers = stickerArray;
        return stickerArray;
     }).catch(^(NSError *error){

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/db/WKReminderDB.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/db/WKReminderDB.m
@@ -59,10 +59,12 @@ static WKReminderDB *_instance;
     }
     // [ReminderTrace] 写库入口,server sync 和本地补偿都走这里.
     for (WKReminder *r in reminders) {
+        #if DEBUG
         NSLog(@"[ReminderTrace] DB addOrUpdate channelId=%@ type=%d reminderID=%lld msgId=%llu msgSeq=%u done=%d isLocate=%d publisher=%@ version=%lld",
               r.channel.channelId, r.channel.channelType,
               r.reminderID, r.messageId, r.messageSeq,
               r.done, r.isLocate, r.publisher ?: @"", r.version);
+        #endif
     }
     __weak typeof(self) weakSelf = self;
     [[WKDB sharedDB].dbQueue inTransaction:^(FMDatabase * _Nonnull db, BOOL * _Nonnull rollback) {
@@ -134,7 +136,9 @@ static WKReminderDB *_instance;
         return;
     }
     // [ReminderTrace] 标记 reminder 为 done(用户阅读到了对应消息).
+    #if DEBUG
     NSLog(@"[ReminderTrace] DB updateDone ids=%@", [ids componentsJoinedByString:@","]);
+    #endif
     [[WKDB sharedDB].dbQueue inDatabase:^(FMDatabase * _Nonnull db) {
         [db executeUpdate:[NSString stringWithFormat:@"%@ (%@)",SQL_UPDATE_DONE,[ids componentsJoinedByString:@","]],@([[NSDate date] timeIntervalSince1970])];
     }];

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKChatManager.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKChatManager.m
@@ -795,10 +795,12 @@
         reminder.done = NO;
         reminder.version = 0;
         // [ReminderTrace] 本地 mention 补偿创建路径(@所有人 / mention.humans).
+        #if DEBUG
         NSLog(@"[ReminderTrace] localCompensation create channelId=%@ type=%d msgSeq=%u msgId=%llu reminderID=%lld publisher=%@",
               message.channel.channelId, message.channel.channelType,
               message.messageSeq, message.messageId,
               reminder.reminderID, reminder.publisher);
+        #endif
         [[WKReminderDB shared] addOrUpdates:@[reminder]];
         [[WKReminderManager shared] updateConversations:[NSSet setWithObject:message.channel]];
     }

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/model/WKConversation.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/model/WKConversation.m
@@ -45,10 +45,19 @@
 - (void)setReminders:(NSArray<WKReminder *> *)reminders {
     _reminders = reminders;
     NSMutableArray *newSimpleReminderArray = [NSMutableArray array];
+    NSString *selfUid = WKSDK.shared.options.connectInfo.uid;
     if(reminders&&reminders.count>0) {
-        
+
         for (WKReminder *reminder  in reminders) {
             if(reminder.publisher && WKSDK.shared.options.connectInfo && [reminder.publisher isEqualToString:WKSDK.shared.options.connectInfo.uid]) {
+                continue;
+            }
+            // 兜底校验：服务端偶发下发脏的 @我 reminder（消息实际未 @ 到自己），
+            // 客户端拿到消息本体后按 mention.uids/humans/all 复核；若消息在本地
+            // 明确未 @ 到自己，则不进入 simpleReminders，避免会话/子区 cell 上
+            // 挂出"没人@我 却提醒"的假 badge。消息未同步到本地时保守放行。
+            // 对齐 web 端 ConversationWrap.isMentionMe 的"看 mention.uids"分支。
+            if(![WKConversation isReminderTrustworthy:reminder selfUid:selfUid]) {
                 continue;
             }
             BOOL exist = false;
@@ -65,10 +74,55 @@
             }else {
                 newSimpleReminderArray[i] = reminder;
             }
-           
+
         }
     }
     self.simpleReminderInners = newSimpleReminderArray;
+}
+
+/// 校验 @我 reminder 是否可信：只有当本地已经拿到 reminder 指向的消息，且能
+/// 明确判断该消息「没有 @ 到自己」（uids 不含自己 + humans=0 + type 非 All/Humans）
+/// 时才拒绝，其它情况一律放行（避免误伤）。返回 NO 表示丢弃。
++ (BOOL)isReminderTrustworthy:(WKReminder *)reminder selfUid:(NSString *)selfUid {
+    if(!reminder) {
+        return YES;
+    }
+    // 非 @我 reminder 走原路
+    if(reminder.type != WKReminderTypeMentionMe) {
+        return YES;
+    }
+    // selfUid / messageId 缺失，无法校验，保守放行
+    if(!selfUid || selfUid.length == 0) {
+        return YES;
+    }
+    if(reminder.messageId == 0) {
+        return YES;
+    }
+    WKMessage *msg = [[WKMessageDB shared] getMessageWithMessageId:reminder.messageId];
+    if(!msg) {
+        // 消息未同步到本地（长时间未登录后 reminder 先到达）：保守放行，
+        // 后续消息补齐 / 用户进入会话时若真是脏 reminder，可靠 orphan-check
+        // 或 done 上报兜底
+        return YES;
+    }
+    WKMentionedInfo *mi = msg.content.mentionedInfo;
+    if(!mi) {
+        // content 未解析出 mentionedInfo（老消息 / 解析失败）：无法反证，放行
+        return YES;
+    }
+    // 广播型 @：@所有人 / @所有人类，视为可能命中人类自己，放行
+    if(mi.type == WK_Mentioned_All || mi.type == WK_Mentioned_Humans || mi.humans) {
+        return YES;
+    }
+    // 明确 @ 到自己
+    if(mi.uids && [mi.uids containsObject:selfUid]) {
+        return YES;
+    }
+    // 消息在本地 + mention 信息完整 + 明确未 @ 自己 → 判定为服务端脏 reminder
+    NSLog(@"[ReminderTrace] drop fake mention reminder: channelId=%@ msgId=%llu msgSeq=%u uids=%@ humans=%d selfUid=%@",
+          reminder.channel.channelId, reminder.messageId, reminder.messageSeq,
+          mi.uids, mi.humans, selfUid);
+    return NO;
 }
 
 

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/model/WKConversation.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/model/WKConversation.m
@@ -119,9 +119,11 @@
         return YES;
     }
     // 消息在本地 + mention 信息完整 + 明确未 @ 自己 → 判定为服务端脏 reminder
+    #if DEBUG
     NSLog(@"[ReminderTrace] drop fake mention reminder: channelId=%@ msgId=%llu msgSeq=%u uids=%@ humans=%d selfUid=%@",
           reminder.channel.channelId, reminder.messageId, reminder.messageSeq,
           mi.uids, mi.humans, selfUid);
+    #endif
     return NO;
 }
 

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/utils/WKMemoryCache.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/utils/WKMemoryCache.m
@@ -31,6 +31,11 @@
             [self.cacheDictonary removeObjectForKey:key];
         }
 
+        // cacheArray 是 FIFO 淘汰序, 先 remove 再 addObject 保证同一 key 只占
+        // 一个槽位。老实现直接 addObject: 允许重复, 高频 setCache 同一 key 会
+        // 让 cacheArray 无界膨胀; cleanCache 里 removeObject: 又只删首个匹配,
+        // 淘汰错位 → dict 里陈旧对象长期存活, 放大 Bugly #9089 race 概率。
+        [self.cacheArray removeObject:key];
         [self.cacheArray addObject:key];
 
         [self cleanCache];
@@ -38,9 +43,17 @@
 }
 -(id) getCache:(NSString*)key {
     if (!key) return nil;
+    // 用显式 __strong 本地承接返回值, 而不是 `return dict[key]`。
+    // 后者依赖 `objc_retainAutoreleasedReturnValue` fast-path 才能在 @synchronized
+    // 退出前完成 +1, 极端场景 (Bugly #9089 iOS 26 上 objc_release_x0 SEGV) 下
+    // 拿不到 retain 的 val 在锁外被别的线程 setCache 顶掉即被解引, ARC 尾部的
+    // objc_autoreleaseReturnValue 踩释放页。显式本地强引用后, retain 落在锁内、
+    // release 落在返回后, 无论 RRV fast-path 是否命中都安全。
+    id __strong value = nil;
     @synchronized (self) {
-        return self.cacheDictonary[key];
+        value = [self.cacheDictonary objectForKey:key];
     }
+    return value;
 }
 // 清理缓存 (调用方已在 @synchronized(self) 内,本方法不再重入加锁)
 -(void) cleanCache {

--- a/OctoiOS.xcodeproj/project.pbxproj
+++ b/OctoiOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/OctoiOS.xcodeproj/project.pbxproj
+++ b/OctoiOS.xcodeproj/project.pbxproj
@@ -149,7 +149,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		4B5FF74D2F908A62005CCF01 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		4B5FF74D2F908A62005CCF01 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -159,7 +159,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		4B5FF7422F908A62005CCF01 /* ShareExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4B5FF74D2F908A62005CCF01 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShareExtension; sourceTree = "<group>"; };
+		4B5FF7422F908A62005CCF01 /* ShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				4B5FF74D2F908A62005CCF01 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -538,13 +549,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -559,13 +566,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/OctoiOS.xcodeproj/project.pbxproj
+++ b/OctoiOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -149,7 +149,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		4B5FF74D2F908A62005CCF01 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */ = {
+		4B5FF74D2F908A62005CCF01 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -159,18 +159,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		4B5FF7422F908A62005CCF01 /* ShareExtension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				4B5FF74D2F908A62005CCF01 /* Exceptions for "ShareExtension" folder in "ShareExtension" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = ShareExtension;
-			sourceTree = "<group>";
-		};
+		4B5FF7422F908A62005CCF01 /* ShareExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4B5FF74D2F908A62005CCF01 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShareExtension; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -549,9 +538,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -566,9 +559,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OctoiOSBase-OctoiOS/Pods-OctoiOSBase-OctoiOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -981,7 +978,7 @@
 				CODE_SIGN_ENTITLEMENTS = Octo/Octo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "$(APPLE_TEAM_ID)";
 				ENABLE_BITCODE = NO;
@@ -1091,7 +1088,7 @@
 				CODE_SIGN_ENTITLEMENTS = Octo/Octo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "$(APPLE_TEAM_ID)";
 				ENABLE_BITCODE = NO;


### PR DESCRIPTION
## Summary

累计 11 个 commit，分四组：

- **feat(channel-history-search)** — 群 / 私聊 / 子区 设置页新增「查找聊天内容」纯 API 搜索页，含流式视频播放（底部进度条 + SF Symbol 图标）
- **fix(bubble-render)** — 气泡重叠 / 回前台空白 / pulldown 桥接 + reset-load 稳定性 + heightCache 三重失效 + 异步 sender info 全 dp 收敛
- **fix(iPad/Bugly 崩溃)**
  - iPad popover 补齐 `sourceView` 消除 actionSheet / UIActivityViewController 崩溃
  - `startReminderAnimation` 拿掉空 `performBatchUpdates` 消除 iPad 崩溃
  - Bugly #9089 `WKMemoryCache` sizeCache / lastLineCache 首建 race + `getCache:` 返回值 retain 前置
  - Bugly `-[WKSticker count]` unrecognized selector：`loadCollectStickers` 对 API 响应类型归一化
- **fix(unread + file-preview)**
  - 最近 tab 父群 badge fold 子区未读 + 脏「@我」reminder 本地兜底
  - xls/xlsx 预览改走 `QLPreviewController`，内容按原文档配色不做主题化

## Commit 列表

- `5af7510` fix(file-preview): xls/xlsx → QLPreviewController
- `f9d84a7` fix(collect-stickers): loadCollectStickers 归一化 response 类型
- `76873fc` fix(memory-cache): sizeCache/lastLineCache 首建 race + getCache retain 前置 (Bugly #9089)
- `de444fc` fix(ipad-popover): actionSheet / popover VC / UIActivityViewController sourceView
- `6b750ee` fix(reminder-locate): startReminderAnimation 空 performBatchUpdates
- `fd44679` fix(unread): 父群 badge fold 子区未读 + @我 reminder 本地兜底
- `8ef87d9` feat(channel-history-search): 视频播放器底部进度条 + SF Symbol 图标
- `1ce7ac5` fix(bubble-render): reset-load 稳定性 + heightCache 三重失效
- `c6b3b92` feat(channel-history-search): 视频改流式播放 + 中央 loading 转圈
- `1aba197` fix(bubble-render): 气泡重叠 / 回前台空白 / pulldown 桥接 一揽子修复
- `62f3607` feat(channel-history-search): 群/私/子区 设置页新增「查找聊天内容」

## Test plan

- [ ] 频道查找：群 / 私聊 / 子区 设置页入口进入，关键词命中高亮 / 上下文预览 / 跳转原消息
- [ ] 视频搜索结果：流式播放 + 中央 loading + 底部进度条拖拽
- [ ] iPad：长按消息 / 分享菜单 / 转发面板 / actionSheet 全流程无崩溃（原 Bugly popover 场景）
- [ ] iPad：@ 提醒定位 → 会话内滚动锚定，无 performBatchUpdates 崩溃
- [ ] fresh install (iOS 26+) 首次进大群，reloadData 期间不再命中 objc_release_x0 SEGV（Bugly #9089）
- [ ] 收藏 0 张 / N 张贴纸 + 服务端异常帧（单 dict / null）→ 长按 GIF/贴纸消息，"添加表情"入口不崩
- [ ] 会话列表：父群含未读子区时 badge 折叠计数正确；@我 reminder 脏数据兜底
- [ ] 气泡：pulldown / pullup / 后台切回，无重叠 / 无空白 / heightCache 不毒
- [ ] 文件预览：xlsx 深色模式下白色文档岛 + 暗色顶栏，保留原文档配色（红色警戒行等语义色不被反色）
- [ ] Bugly 灰度 3-5 天：`objc_release_x0` / `-[WKSticker count]` 相关堆栈清零

🤖 Generated with [Claude Code](https://claude.com/claude-code)