### PR TITLE
fix(docs): hand off viewer space on mobile open

### DIFF
--- a/Modules/WuKongBase/Example/LiMaoBase.xcodeproj/project.pbxproj
+++ b/Modules/WuKongBase/Example/LiMaoBase.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D0C500000000000000000001 /* WKDocsViewerSpaceHandoffTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C500000000000000000002 /* WKDocsViewerSpaceHandoffTests.m */; };
 		520BE45CD0E8F8F4E2EF21AC /* WKFollowSidebarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B6EA9F5D6FE167093BF2D24 /* WKFollowSidebarTests.m */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -57,6 +58,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D0C500000000000000000002 /* WKDocsViewerSpaceHandoffTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WKDocsViewerSpaceHandoffTests.m; sourceTree = "<group>"; };
 		150887FD5F014CC653E028F5 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		31E97EA6FA728C7061776910 /* LiMaoBase.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LiMaoBase.podspec; path = ../LiMaoBase.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		344B3E144C0E72E5FC31C6B1 /* Pods-LiMaoBase_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiMaoBase_Example.debug.xcconfig"; path = "Target Support Files/Pods-LiMaoBase_Example/Pods-LiMaoBase_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				6003F5BB195388D20070C39A /* Tests.m */,
+				D0C500000000000000000002 /* WKDocsViewerSpaceHandoffTests.m */,
 				85EB8C00E7C49A151B670678 /* WKExternalViewerResolverTests.m */,
 				A97C0DE197001001E7B8C3A2 /* WKGroupQRCodeInfoModelTests.m */,
 				B2CA62921B187BCA0DFC746C /* WKMentionUserCellTests.m */,
@@ -543,6 +546,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6003F5BC195388D20070C39A /* Tests.m in Sources */,
+				D0C500000000000000000001 /* WKDocsViewerSpaceHandoffTests.m in Sources */,
 				93FBC126DB4B04BC75AF04E2 /* WKExternalViewerResolverTests.m in Sources */,
 				A97C0DE197001001E7B8C3A1 /* WKGroupQRCodeInfoModelTests.m in Sources */,
 				B49640EA6FC4C273CD92871A /* WKMentionUserCellTests.m in Sources */,

--- a/Modules/WuKongBase/Example/Tests/WKDocsViewerSpaceHandoffTests.m
+++ b/Modules/WuKongBase/Example/Tests/WKDocsViewerSpaceHandoffTests.m
@@ -1,0 +1,63 @@
+// Copyright 2026 MININGLAMP Technology and the OCTO contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@import XCTest;
+#import "WKDocsViewerSpaceHandoff.h"
+
+@interface WKDocsViewerSpaceHandoffTests : XCTestCase
+@end
+
+@implementation WKDocsViewerSpaceHandoffTests
+
+- (void)testAllowsSameOriginViewerRoutesAndEffectiveDefaultPort {
+    NSString *base = @"https://octo.example/api/v1/";
+    XCTAssertTrue(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example/d/doc-1"], base));
+    XCTAssertTrue(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example:443/ppt/d/deck-1/"], base));
+    XCTAssertTrue(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example/docs/deck-1/present?slide=2"], base));
+}
+
+- (void)testRejectsOriginSpoofingAndPortMismatch {
+    NSString *base = @"https://octo.example/api/v1/";
+    XCTAssertFalse(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example.evil/d/doc-1"], base));
+    XCTAssertFalse(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example@evil.example/d/doc-1"], base));
+    XCTAssertFalse(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"http://octo.example/d/doc-1"], base));
+    XCTAssertFalse(WKIsTrustedDocsViewerURL([NSURL URLWithString:@"https://octo.example:8443/d/doc-1"], base));
+}
+
+- (void)testRejectsNonViewerAndNearMatchPaths {
+    NSString *base = @"https://octo.example/api/v1/";
+    NSArray<NSString *> *URLs = @[
+        @"https://octo.example/", @"https://octo.example/docs", @"https://octo.example/d/",
+        @"https://octo.example/d/doc-1/edit", @"https://octo.example/ppt/d/deck-1/edit",
+        @"https://octo.example/docs/deck-1", @"https://octo.example/docs/deck-1/present/extra"
+    ];
+    for (NSString *value in URLs) {
+        XCTAssertFalse(WKIsTrustedDocsViewerURL([NSURL URLWithString:value], base), @"%@", value);
+    }
+}
+
+- (void)testScriptSetsEscapedSnapshot {
+    NSString *lineSeparator = [NSString stringWithFormat:@"%C", (unichar)0x2028];
+    NSString *paragraphSeparator = [NSString stringWithFormat:@"%C", (unichar)0x2029];
+    NSString *space = [NSString stringWithFormat:@"space'\\\"\n%@%@</script>", lineSeparator, paragraphSeparator];
+    NSString *script = WKDocsViewerSpaceJavaScript(space, @"https://octo.example/api/v1");
+    XCTAssertTrue([script containsString:@"localStorage.setItem('currentSpaceId'"]);
+    XCTAssertTrue([script containsString:@"space'\\\\\\\""]);
+    XCTAssertTrue([script containsString:@"\\n"]);
+    XCTAssertTrue([script containsString:@"\\u2028"]);
+    XCTAssertTrue([script containsString:@"\\u2029"]);
+    XCTAssertTrue([script containsString:@"<\\/script>"]);
+    XCTAssertFalse([script containsString:lineSeparator]);
+    XCTAssertFalse([script containsString:paragraphSeparator]);
+}
+
+- (void)testScriptRemovesForNilOrEmptySpace {
+    NSString *remove = WKDocsViewerSpaceJavaScript(nil, @"https://octo.example/api/v1");
+    XCTAssertTrue([remove containsString:@"localStorage.removeItem('currentSpaceId')"]);
+    XCTAssertTrue([remove containsString:@"p===\"https\""]);
+    XCTAssertTrue([remove containsString:@"h===\"octo.example\""]);
+    XCTAssertTrue([remove containsString:@"n===443"]);
+    XCTAssertEqualObjects(WKDocsViewerSpaceJavaScript(@"", @"https://octo.example/api/v1"), remove);
+}
+
+@end

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKDocsViewerSpaceHandoff.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKDocsViewerSpaceHandoff.h
@@ -1,0 +1,17 @@
+// Copyright 2026 MININGLAMP Technology and the OCTO contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Returns YES only for same-origin, standalone Docs viewer/presentation URLs.
+FOUNDATION_EXPORT BOOL WKIsTrustedDocsViewerURL(NSURL * _Nullable URL,
+                                                NSString * _Nullable apiBaseURL);
+
+/// Builds the document-start script that snapshots the native viewer Space.
+/// A nil or empty value removes the key so pooled web content cannot reuse stale state.
+FOUNDATION_EXPORT NSString *WKDocsViewerSpaceJavaScript(NSString * _Nullable currentSpaceId,
+                                                        NSString *apiBaseURL);
+
+NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKDocsViewerSpaceHandoff.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKDocsViewerSpaceHandoff.m
@@ -1,0 +1,57 @@
+// Copyright 2026 MININGLAMP Technology and the OCTO contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#import "WKDocsViewerSpaceHandoff.h"
+
+static NSNumber *WKEffectivePort(NSURLComponents *components) {
+    if (components.port != nil) return components.port;
+    NSString *scheme = components.scheme.lowercaseString;
+    if ([scheme isEqualToString:@"https"]) return @443;
+    if ([scheme isEqualToString:@"http"]) return @80;
+    return nil;
+}
+
+static BOOL WKIsDocsViewerPath(NSString *path) {
+    if (path.length == 0) return NO;
+    NSRegularExpression *expression = [NSRegularExpression regularExpressionWithPattern:@"^/(?:d/[^/]+|ppt/d/[^/]+|docs/[^/]+/present)/?$"
+                                                                                  options:0
+                                                                                    error:nil];
+    return [expression firstMatchInString:path options:0 range:NSMakeRange(0, path.length)] != nil;
+}
+
+BOOL WKIsTrustedDocsViewerURL(NSURL *URL, NSString *apiBaseURL) {
+    if (URL == nil || apiBaseURL.length == 0) return NO;
+
+    NSURLComponents *candidate = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+    NSURLComponents *server = [NSURLComponents componentsWithString:apiBaseURL];
+    if (candidate.scheme.length == 0 || candidate.host.length == 0 ||
+        server.scheme.length == 0 || server.host.length == 0) return NO;
+
+    BOOL sameOrigin = [candidate.scheme.lowercaseString isEqualToString:server.scheme.lowercaseString] &&
+        [candidate.host.lowercaseString isEqualToString:server.host.lowercaseString] &&
+        [WKEffectivePort(candidate) isEqualToNumber:WKEffectivePort(server)];
+    return sameOrigin && WKIsDocsViewerPath(candidate.percentEncodedPath);
+}
+
+static NSString *WKJSONString(NSString *value) {
+    NSData *data = [NSJSONSerialization dataWithJSONObject:@[value ?: @""] options:0 error:nil];
+    NSString *arrayJSON = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSString *valueJSON = arrayJSON.length >= 2 ? [arrayJSON substringWithRange:NSMakeRange(1, arrayJSON.length - 2)] : @"\"\"";
+    valueJSON = [valueJSON stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%C", (unichar)0x2028]
+                                                     withString:@"\\u2028"];
+    return [valueJSON stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%C", (unichar)0x2029]
+                                                withString:@"\\u2029"];
+}
+
+NSString *WKDocsViewerSpaceJavaScript(NSString *currentSpaceId, NSString *apiBaseURL) {
+    NSURLComponents *server = [NSURLComponents componentsWithString:apiBaseURL];
+    NSString *scheme = server.scheme.lowercaseString ?: @"";
+    NSString *host = server.host.lowercaseString ?: @"";
+    NSNumber *port = WKEffectivePort(server);
+    NSString *action = currentSpaceId.length > 0
+        ? [NSString stringWithFormat:@"localStorage.setItem('currentSpaceId',%@);", WKJSONString(currentSpaceId)]
+        : @"localStorage.removeItem('currentSpaceId');";
+    return [NSString stringWithFormat:
+        @"(function(){try{var p=location.protocol.slice(0,-1).toLowerCase(),h=location.hostname.toLowerCase(),n=location.port?Number(location.port):(p==='https'?443:(p==='http'?80:0)),r=/^\\/(?:d\\/[^/]+|ppt\\/d\\/[^/]+|docs\\/[^/]+\\/present)\\/?$/;if(p===%@&&h===%@&&n===%@&&r.test(location.pathname)){%@}}catch(e){}})();",
+        WKJSONString(scheme), WKJSONString(host), port ?: @0, action];
+}

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKWebViewVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/Webview/WKWebViewVC.m
@@ -16,6 +16,7 @@
 #import "WKConversationVC.h"
 #import "WKWebViewService.h"
 #import "WKCSVRenderer.h"
+#import "WKDocsViewerSpaceHandoff.h"
 #include <libcmark_gfm/cmark-gfm.h>
 #include <libcmark_gfm/cmark-gfm-core-extensions.h>
 @interface WKWebViewVC ()<WKUIDelegate,WKNavigationDelegate,UIScrollViewDelegate>
@@ -825,6 +826,19 @@
  @param webView wkwebview
  */
 - (void)addUserScript:(WKWebView *)webView {
+    // Standalone Docs reads this key during bootstrap. Capture the native value now and
+    // install it at document-start so app scripts cannot observe stale pooled storage.
+    // Scope is deliberately narrow: exact server origin + explicit viewer routes only.
+    if (WKIsTrustedDocsViewerURL(self.url, [WKApp shared].config.apiBaseUrl)) {
+        NSString *spaceId = [[NSUserDefaults standardUserDefaults] stringForKey:@"currentSpaceId"];
+        NSString *apiBaseURL = [WKApp shared].config.apiBaseUrl;
+        WKUserScript *spaceScript = [[WKUserScript alloc]
+            initWithSource:WKDocsViewerSpaceJavaScript(spaceId, apiBaseURL)
+            injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+            forMainFrameOnly:YES];
+        [webView.configuration.userContentController addUserScript:spaceScript];
+    }
+
     // 让网页（含登录 OIDC 页）跟随 App 内语言切换，而不是 iOS 系统语言。
     // 背景：WKWebView 的 navigator.language / navigator.languages 取自
     // NSLocale.preferredLanguages（设备系统语言），不受 [WKApp shared].config.langue 影响；


### PR DESCRIPTION
## Summary
- inject the native current Space at document start for trusted standalone Docs routes
- clear stale WKWebView Space state when the native selection is empty
- enforce the same origin/path allowlist in native code and in the injected script
- add focused route, origin, stale-state, and script-escaping tests

## Linked issue
Closes #77

## How verified
- independent review: P0/P1 = 0
- Foundation-only helper compiled with ARC and `-Wall -Wextra -Werror`
- helper behavior harness and generated JavaScript execution passed
- `project.pbxproj` validation and `git diff --check` passed
- full XCTest/build was not run locally because full Xcode/CocoaPods is unavailable; CI must run platform tests and build

## Comprehension
### What does this change actually do?
Before, standalone Docs pages opened in WKWebView without the viewer's native current Space. Now exact trusted Docs routes receive one document-start, main-frame-only Space snapshot in `localStorage.currentSpaceId`; nil or empty input removes stale state.

### What could break?
WKWebView startup for standalone Doc, PPT, and presentation routes. The allowlist, effective-port check, and runtime recheck keep unrelated and external pages untouched.

### How do you know it works?
The production helper compiles and passes behavior probes for origin/path gating, stale removal, and script escaping. The test target registration and project file validate; independent review found no P0/P1 issue. CI remains required for full XCTest/build evidence.
