### PR TITLE
fix(conversation-list): iPad 横屏下消息列表页头部不能铺满整行

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
@@ -514,6 +514,13 @@
 -(void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
+    // 兜底: viewWillTransitionToSize 在本 VC 被压在导航栈里(不是最顶层,比如打开了某个
+    // 会话)时不保证会触发(iOS 已知问题, rdar://24277475),压栈期间如果发生了尺寸变化,
+    // 只靠那个回调不会跟着重新布局,返回时 header/tab栏/导航栏就可能还停在旧宽度。
+    // 这里每次页面可见都按当前宽度重新校正一遍,不再只依赖旋转回调这一条路径。
+    [self wk_relayoutNavigationBarForWidth:self.view.lim_width];
+    [self layoutFixedHeader];
+
     [self refreshTitle];
     [self hiddenRightItem:NO];
 
@@ -1197,10 +1204,10 @@
 /// 创建固定在顶部的搜索栏容器（不随 tableView 滚动）
 -(void) setupFixedHeader {
     CGFloat navBottom = self.navigationBar.lim_bottom;
-    _fixedHeaderContainer = [[UIView alloc] initWithFrame:CGRectMake(0, navBottom, WKScreenWidth, 0)];
+    _fixedHeaderContainer = [[UIView alloc] initWithFrame:CGRectMake(0, navBottom, self.view.lim_width, 0)];
     _fixedHeaderContainer.backgroundColor = [WKApp shared].config.backgroundColor;
 
-    WKSearchbarView *searchbar = [[WKSearchbarView alloc] initWithFrame:CGRectMake(15, 6, WKScreenWidth - 30, 36)];
+    WKSearchbarView *searchbar = [[WKSearchbarView alloc] initWithFrame:CGRectMake(15, 6, self.view.lim_width - 30, 36)];
     searchbar.placeholder = LLang(@"搜索");
     searchbar.layer.masksToBounds = YES;
     searchbar.onClick = ^{
@@ -1214,6 +1221,10 @@
 }
 
 /// 重新布局固定头部（搜索栏 + tabView）并调整 tableView 的 frame
+// 注意: 这里原先用 WKScreenWidth([UIScreen mainScreen].bounds.size.width) 算宽度——
+// iOS 8 之后 UIScreen.bounds 不随界面方向旋转,永远是竖屏原始宽度,iPad 横屏时
+// 搜索栏/tab 栏/固定头部容器会停在竖屏宽度不铺满。改用 self.view.lim_width(旋转后
+// 会随 viewWillTransitionToSize 触发的重新布局实时更新)。
 -(void) layoutFixedHeader {
     CGFloat navBottom = self.navigationBar.lim_bottom;
     CGFloat y = 0;
@@ -1221,21 +1232,51 @@
     // 搜索栏（左右 15pt 间距）
     UIView *searchbar = [_fixedHeaderContainer viewWithTag:9990];
     if (searchbar && !searchbar.hidden) {
-        searchbar.frame = CGRectMake(15, y + 6, WKScreenWidth - 30, 36);
+        searchbar.frame = CGRectMake(15, y + 6, self.view.lim_width - 30, 36);
         y = searchbar.lim_bottom + 6;
     }
 
     // tab 栏
     if (_conversationTabView) {
-        _conversationTabView.frame = CGRectMake(0, y, WKScreenWidth, 44);
+        _conversationTabView.frame = CGRectMake(0, y, self.view.lim_width, 44);
         y = _conversationTabView.lim_bottom;
     }
 
-    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, WKScreenWidth, y);
+    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, self.view.lim_width, y);
 
     // 调整 tableView 位置到固定头部下方
     CGFloat tableTop = _fixedHeaderContainer.lim_bottom;
     self.tableView.frame = CGRectMake(0, tableTop, self.view.lim_width, self.view.lim_height - tableTop);
+}
+
+// iPad 支持分屏,系统不允许通过 supportedInterfaceOrientations 锁方向,只能老实做旋转
+// 自适应布局。这个页面原本没有任何旋转处理:固定头部(搜索栏+tab栏)只在 viewDidLoad
+// 链路里布局过一次,旋转后不会再重新走 layoutFixedHeader,加上其内部又用了不随方向变化
+// 的 WKScreenWidth(见上面 layoutFixedHeader 的注释),导致横屏时除了系统 UITabBar
+// 之外的内容全部停在竖屏宽度。这里补上旋转回调,同时顺带修一下 navigationBar 的同类问题
+// (WKNavigationBar 自己没有 layoutSubviews,宽度和 title/rightView 位置都是一次性算好的)。
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak typeof(self) weakSelf = self;
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [weakSelf wk_relayoutNavigationBarForWidth:size.width];
+        [weakSelf layoutFixedHeader];
+    } completion:nil];
+}
+
+// navigationBar 的 title/rightView 位置都是在各自 setter 里按"当时"的 self.lim_width 算好
+// 就定死,不会随外部 frame 变化自动重排。这里只改它自己的宽度,再用同一份值重新触发一遍
+// title/rightView 的 setter,逼它们按新宽度重新居中/靠右——不在这里重复实现 WKNavigationBar
+// 内部那套定位公式,避免两处代码各算一遍、以后改了一处忘了另一处。
+- (void)wk_relayoutNavigationBarForWidth:(CGFloat)width {
+    CGRect frame = self.navigationBar.frame;
+    if (frame.size.width == width) return;
+    frame.size.width = width;
+    self.navigationBar.frame = frame;
+    self.navigationBar.title = self.navigationBar.title;
+    if (self.navigationBar.rightView) {
+        self.navigationBar.rightView = self.navigationBar.rightView;
+    }
 }
 
 - (WKConversationListTableView *)tableView{


### PR DESCRIPTION
Closes #85

## What

iPad 横屏下，消息列表页的头部（搜索栏 / 分类 tab 行 / 导航栏）不能铺满整行，仍然按竖屏宽度显示；从其他页面（如打开一个会话）返回后同样会看到未铺满的状态。

## Why

- `setupFixedHeader` / `layoutFixedHeader` 依赖的 `WKScreenWidth` 宏取的是 `[UIScreen mainScreen].bounds.size.width`，从 iOS 8 起就被冻结在竖屏宽度，不随旋转变化，导致头部宽度计算始终按竖屏算。
- 该 VC 的重新布局原本只能靠 `viewWillTransitionToSize:withTransitionCoordinator:` 触发。但根据 Apple 已知问题 rdar://24277475，该回调在本 VC 不是导航栈最顶层控制器时（例如上面压了一个聊天页）不保证被调用，仅靠这一条路径无法覆盖所有场景。

## How

1. `setupFixedHeader` / `layoutFixedHeader` 改用 `self.view.lim_width`（跟随实际视图宽度），不再用被冻结的 `WKScreenWidth`。
2. 新增 `viewWillTransitionToSize:withTransitionCoordinator:` 覆盖，旋转时通过 `wk_relayoutNavigationBarForWidth:` + `layoutFixedHeader` 重新布局导航栏与固定头部。
3. `viewWillAppear:` 中同样执行一次上述重新布局，保证页面每次可见时都按当前宽度校正，不依赖旋转回调是否被调用。

## Checklist

- [x] Code compiles with no new warnings
- [ ] Linter and formatter pass
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally
- [x] Rebased onto latest `main`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-reviewed the full diff from a reviewer's perspective

## Testing

- 本地执行 `xcodebuild -workspace OctoiOS.xcworkspace -scheme OctoContext -sdk iphonesimulator build`，编译通过。

## Breaking Changes

N/A
