### PR TITLE
fix(conversation-list): iPad 横屏下消息列表页返回后布局复位

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.h
@@ -53,6 +53,12 @@ typedef enum : NSUInteger {
 /// 返回点击
 @property(nonatomic,strong) void(^onBack)(void);
 
+/// 宽度变化(旋转 / iPad 分屏)后按新宽度重排自己: 改自身 frame 宽度,并重新定位
+/// titleLabel / leftView / rightView。WKNavigationBar 没有 layoutSubviews,这些位置都是
+/// 在各自 setter 里按"当时"的宽度算好就定死的,外部只改 frame 不会带动它们。
+/// 不覆盖 subtitleLabel(见实现里的说明)。
+- (void)wk_relayoutForWidth:(CGFloat)width;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.m
@@ -121,6 +121,9 @@
 }
 
 
+// 注意: 外部(WKConversationListVC 的 wk_relayoutNavigationBarForWidth:)靠重新赋值同一个
+// title 触发这里的重新居中逻辑,来在旋转后刷新 titleLabel 位置——这个 setter 不能加
+// "值没变就 return" 的早退,否则那条旋转刷新链路会失效。
 - (void)setTitle:(NSString *)title {
     _title = title;
     self.titleLabel.text = title;
@@ -161,6 +164,8 @@
     }
 }
 
+// 注意: 同 setTitle 一样,wk_relayoutNavigationBarForWidth: 靠重新赋值同一个 rightView
+// 触发下面的重新定位逻辑来在旋转后刷新位置——不能加"跟 _rightView 相同就 return"的早退。
 - (void)setRightView:(UIView *)rightView {
     if(!rightView) {
         rightView = [[UIView alloc] init];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKNavigationBar.m
@@ -121,12 +121,32 @@
 }
 
 
-// 注意: 外部(WKConversationListVC 的 wk_relayoutNavigationBarForWidth:)靠重新赋值同一个
-// title 触发这里的重新居中逻辑,来在旋转后刷新 titleLabel 位置——这个 setter 不能加
-// "值没变就 return" 的早退,否则那条旋转刷新链路会失效。
+// 宽度变化后重排自己。外部(旋转/分屏回调)只需要调这一个方法,不要靠"重新赋值同一个
+// title/rightView"去触发 setter 副作用——那种写法会把 setter 永久锁死在"不能加幂等早退"
+// 的状态上,而这是个全模块共用的类。定位公式统一放在下面三个 wk_position* 里,setter 和
+// 这里共用同一份实现。
+//
+// 未覆盖: subtitleLabel。它在 setSubtitle: 里用 WKScreenWidth/2 居中(同一族的老毛病:
+// 用屏幕宽而不是自己的宽,且只算一次),但本页面不用 subtitle,这个 PR 不扩范围,另开处理。
+- (void)wk_relayoutForWidth:(CGFloat)width {
+    if (width <= 0) return;
+    CGRect frame = self.frame;
+    if (frame.size.width != width) {
+        frame.size.width = width;
+        self.frame = frame;
+    }
+    [self wk_positionTitleLabel];
+    [self wk_positionLeftView];
+    [self wk_positionRightView];
+}
+
 - (void)setTitle:(NSString *)title {
     _title = title;
     self.titleLabel.text = title;
+    [self wk_positionTitleLabel];
+}
+
+- (void)wk_positionTitleLabel {
     [self.titleLabel sizeToFit];
 
     if(self.titleLabel.lim_width>titleMaxWidth) {
@@ -140,23 +160,24 @@
     }
     CGFloat statusHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
     self.titleLabel.lim_top = (self.lim_height - statusHeight)/2.0f - self.titleLabel.lim_height/2.0f + statusHeight;
-
-
 }
 
 - (void)setLeftView:(UIView *)leftView {
+    // 传进来的就是当前这个 leftView 时只重定位,不摘下来重挂: removeFromSuperview +
+    // addSubview 会把它挪到 nav bar 的最前面(z-order 变化,长标题会盖住右侧按钮),
+    // 旋转期间每次重排都做一遍完全没必要。
+    if (leftView && leftView == _leftView) {
+        [self wk_positionLeftView];
+        self.titleLabel.hidden = YES;
+        return;
+    }
     if (_leftView) {
         [_leftView removeFromSuperview];
         _leftView = nil;
     }
     if (leftView) {
         _leftView = leftView;
-        CGFloat statusHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
-        if (_leftView.lim_height == 0) {
-            _leftView.lim_height = self.lim_height - statusHeight;
-        }
-        _leftView.lim_left = 16.0f;
-        _leftView.lim_top = (self.lim_height - statusHeight) / 2.0f - _leftView.lim_height / 2.0f + statusHeight;
+        [self wk_positionLeftView];
         [self addSubview:_leftView];
         self.titleLabel.hidden = YES;
     } else {
@@ -164,11 +185,24 @@
     }
 }
 
-// 注意: 同 setTitle 一样,wk_relayoutNavigationBarForWidth: 靠重新赋值同一个 rightView
-// 触发下面的重新定位逻辑来在旋转后刷新位置——不能加"跟 _rightView 相同就 return"的早退。
+- (void)wk_positionLeftView {
+    if (!_leftView) return;
+    CGFloat statusHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+    if (_leftView.lim_height == 0) {
+        _leftView.lim_height = self.lim_height - statusHeight;
+    }
+    _leftView.lim_left = 16.0f;
+    _leftView.lim_top = (self.lim_height - statusHeight) / 2.0f - _leftView.lim_height / 2.0f + statusHeight;
+}
+
 - (void)setRightView:(UIView *)rightView {
     if(!rightView) {
         rightView = [[UIView alloc] init];
+    }
+    // 同 setLeftView:,同一个 view 只重定位不重挂。
+    if(rightView == _rightView) {
+        [self wk_positionRightView];
+        return;
     }
     if(_rightView) {
         [_rightView removeFromSuperview];
@@ -177,23 +211,26 @@
     if(rightView) {
         _rightView = rightView;
        // [_rightView setBackgroundColor:[UIColor clearColor]];
-        
-        CGFloat statusHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
-        if(_rightView.lim_height==0) {
-            _rightView.lim_height = self.lim_height - statusHeight;
-        }
-        
-        if(_rightView.lim_width<=0) {
-            _rightView.lim_width = _rightView.lim_height;
-        }
-        
-        _rightView.lim_left = self.lim_width - _rightView.lim_width - 20.0f;
-         
-         _rightView.lim_top = (self.lim_height - statusHeight)/2.0f - _rightView.lim_height/2.0f + statusHeight;
-        
-       
+        [self wk_positionRightView];
         [self addSubview:_rightView];
     }
+}
+
+- (void)wk_positionRightView {
+    if(!_rightView) return;
+
+    CGFloat statusHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+    if(_rightView.lim_height==0) {
+        _rightView.lim_height = self.lim_height - statusHeight;
+    }
+
+    if(_rightView.lim_width<=0) {
+        _rightView.lim_width = _rightView.lim_height;
+    }
+
+    _rightView.lim_left = self.lim_width - _rightView.lim_width - 20.0f;
+
+    _rightView.lim_top = (self.lim_height - statusHeight)/2.0f - _rightView.lim_height/2.0f + statusHeight;
 }
 
 - (void)setShowBackButton:(BOOL)showBackButton {

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.h
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.h
@@ -19,11 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param array  items，包含字典，字典里面包含标题（title）、图片名（imageName）
  *  @param width  宽度
  *  @param point  三角的顶角坐标（基于window）
+ *  @param window 锚点按钮所在的 window,用于确定遮罩尺寸和菜单挂载位置；传 nil 时兜底用 keyWindow
  *  @param action 点击回调
  */
 - (instancetype)initWithItems:(NSArray <NSDictionary *>*)array
                         width:(CGFloat)width
              triangleLocation:(CGPoint)point
+                       window:(nullable UIWindow *)window
                        action:(void(^)(NSInteger index))action;
 
 /**
@@ -32,11 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param array  items，包含字典，字典里面包含标题（title）、图片名（imageName）
  *  @param width  宽度
  *  @param point  三角的顶角坐标（基于window）
+ *  @param window 锚点按钮所在的 window,用于确定遮罩尺寸和菜单挂载位置；传 nil 时兜底用 keyWindow
  *  @param action 点击回调
  */
 + (void)showWithItems:(NSArray <NSDictionary *>*)array
                 width:(CGFloat)width
      triangleLocation:(CGPoint)point
+               window:(nullable UIWindow *)window
                action:(void(^)(NSInteger index))action;
 
 - (void)show;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
@@ -39,10 +39,14 @@ static CGFloat const kCellHeight = 44;
 {
     if (array.count == 0) return nil;
     if (self = [super init]) {
-        // 用触发按钮所在 window 的实际 bounds 而不是 [UIScreen mainScreen].bounds——后者是
-        // 竖屏原生宽度,不随界面方向刷新,iPad 横屏下遮罩和下面的菜单锚点都会按错误的窄宽度算,
-        // 跟已经移到真实横屏右边缘的触发按钮脱节。调用方只传一次 window(通常是按钮自己的
-        // .window),这里和 show 里都直接用它,不再各自独立查一遍 keyWindow。
+        // 遮罩尺寸用触发按钮所在 window 的 bounds,而不是 [UIScreen mainScreen].bounds:
+        // Info.plist 没有 UIRequiresFullScreen,Split View / Slide Over / Stage Manager 下
+        // app 只占屏幕一部分,屏幕尺寸会高估可用区域,遮罩和下面按 winW 反推的菜单锚点就会
+        // 跟真实按钮位置脱节。要贴合的是 window,不是 screen。
+        // (注: UIScreen.bounds 自 iOS 8 起是跟随界面方向的,不存在"被冻结在竖屏宽度";
+        //  方向无关的是 nativeBounds / fixedCoordinateSpace。别把这里的理由写成方向问题。)
+        // 调用方只传一次 window(通常是按钮自己的 .window),这里和 show 里都直接用它,
+        // 不再各自独立查一遍 keyWindow。
         UIWindow *hostWindow = window ?: [UIApplication sharedApplication].keyWindow;
         self.hostWindow = hostWindow;
         self.frame = hostWindow ? hostWindow.bounds : [UIScreen mainScreen].bounds;
@@ -71,19 +75,20 @@ static CGFloat const kCellHeight = 44;
         const CGFloat titleRightMargin = 12;
         CGFloat bucketWidth = ceil(maxTextWidth + titleStart + titleRightMargin);
         CGFloat finalWidth = MAX(width, bucketWidth);
-        // 用遮罩自身宽度(= 实际 window 宽度,见 self.frame 赋值)代替不旋转的
-        // SCREEN_WIDTH,否则 iPad 横屏下菜单会锚在竖屏窄宽度上远离按钮。
+        // 用遮罩自身宽度(= 实际 window 宽度,见 self.frame 赋值)代替 SCREEN_WIDTH,
+        // 理由同上: 分屏下屏幕宽度不等于 app 可用宽度。
         CGFloat winW = self.bounds.size.width;
         finalWidth = MIN(finalWidth, winW * 0.8);    // 极端长翻译时让 label 自己截断, 不出屏
 
         // 菜单位置以传入的 triangleLocation(point.x) 为锚——三角尖点在按钮中心,
         // 菜单右边缘距三角尖点 25pt(让三角底座 ±10pt 完全落在菜单顶边内部,右侧留 15pt
-        // 呼吸),两侧各留至少 5pt 边距;iPad 横屏/分屏下用真实 window 宽度兜底,
-        // 不再锚死在竖屏 SCREEN_WIDTH 上。
+        // 呼吸),两侧各留至少 5pt 边距;分屏/横屏下用真实 window 宽度兜底。
         CGFloat menuRightX = MIN(point.x + 25, winW - 5);
-        // 三角尖点也要收进菜单的水平范围内,否则触发按钮太贴边时三角会画到菜单外面去。
-        _trianglePoint.x = MIN(MAX(point.x, menuRightX - finalWidth + 10), menuRightX - 10);
         CGFloat menuX = MAX(menuRightX - finalWidth, 5);
+        // 三角尖点必须收在菜单"真实"水平范围内。这里必须用 menuX 反推,不能用
+        // menuRightX - finalWidth: menuX 带 5pt 左边界地板,触发按钮极度贴左时两者不相等,
+        // 拿 menuRightX 算就是按一个并不存在的矩形夹取,三角底座 ±10pt 仍会画到菜单外面。
+        _trianglePoint.x = MIN(MAX(point.x, menuX + 10), menuX + finalWidth - 10);
 
         // 创建tableView
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(menuX, point.y + 10, finalWidth, kCellHeight * array.count) style:UITableViewStylePlain];

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
@@ -37,7 +37,11 @@ static CGFloat const kCellHeight = 44;
 {
     if (array.count == 0) return nil;
     if (self = [super init]) {
-        self.frame = [UIScreen mainScreen].bounds;
+        // 用 keyWindow 的实际 bounds 而不是 [UIScreen mainScreen].bounds——后者是竖屏原生
+        // 宽度,不随界面方向刷新,iPad 横屏下遮罩和下面的菜单锚点都会按错误的窄宽度算,
+        // 跟已经移到真实横屏右边缘的触发按钮脱节。
+        UIWindow *keyWin = [UIApplication sharedApplication].keyWindow;
+        self.frame = keyWin ? keyWin.bounds : [UIScreen mainScreen].bounds;
         self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
         self.alpha = 0;
         _tableData = [array copy];
@@ -63,10 +67,21 @@ static CGFloat const kCellHeight = 44;
         const CGFloat titleRightMargin = 12;
         CGFloat bucketWidth = ceil(maxTextWidth + titleStart + titleRightMargin);
         CGFloat finalWidth = MAX(width, bucketWidth);
-        finalWidth = MIN(finalWidth, SCREEN_WIDTH * 0.8);    // 极端长翻译时让 label 自己截断, 不出屏
+        // 用遮罩自身宽度(= 实际 window 宽度,见 self.frame 赋值)代替不旋转的
+        // SCREEN_WIDTH,否则 iPad 横屏下菜单会锚在竖屏窄宽度上远离按钮。
+        CGFloat winW = self.bounds.size.width;
+        finalWidth = MIN(finalWidth, winW * 0.8);    // 极端长翻译时让 label 自己截断, 不出屏
+
+        // 菜单位置以传入的 triangleLocation(point.x) 为锚——三角尖点在按钮中心,
+        // 菜单右边缘距三角尖点 25pt(让三角底座 ±10pt 完全落在菜单顶边内部,右侧留 15pt
+        // 呼吸),两侧各留至少 5pt 边距;iPad 横屏/分屏下用真实 window 宽度兜底,
+        // 不再锚死在竖屏 SCREEN_WIDTH 上。
+        CGFloat menuRightX = MIN(point.x + 25, winW - 5);
+        CGFloat menuX = MAX(menuRightX - finalWidth, 5);
+        menuRightX = menuX + finalWidth;
 
         // 创建tableView
-        _tableView = [[UITableView alloc] initWithFrame:CGRectMake(SCREEN_WIDTH - finalWidth - 5, point.y + 10, finalWidth, kCellHeight * array.count) style:UITableViewStylePlain];
+        _tableView = [[UITableView alloc] initWithFrame:CGRectMake(menuX, point.y + 10, finalWidth, kCellHeight * array.count) style:UITableViewStylePlain];
         _tableView.delegate = self;
         _tableView.dataSource = self;
         _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
@@ -105,8 +120,9 @@ static CGFloat const kCellHeight = 44;
 #pragma mark - show or hide
 - (void)show {
     [[UIApplication sharedApplication].keyWindow addSubview:self];
-    // 设置右上角为transform的起点（默认是中心点）
-    _tableView.layer.position = CGPointMake(SCREEN_WIDTH - 5, _trianglePoint.y + 10);
+    // anchorPoint = (1,0): position.x 即菜单右边缘;y 即菜单顶边。
+    // 用 menu 自己 frame 的右边缘而不是 SCREEN_WIDTH,确保旋转后菜单仍紧贴三角尖点。
+    _tableView.layer.position = CGPointMake(CGRectGetMaxX(_tableView.frame), _trianglePoint.y + 10);
     // 向右下transform
     _tableView.layer.anchorPoint = CGPointMake(1, 0);
     _tableView.transform = CGAffineTransformMakeScale(0.0001, 0.0001);

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/Common/WKPopMenuView.m
@@ -25,6 +25,7 @@ static CGFloat const kCellHeight = 44;
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NSArray *tableData;
 @property (nonatomic, assign) CGPoint trianglePoint;
+@property (nonatomic, weak) UIWindow *hostWindow;
 @property (nonatomic, copy) void(^action)(NSInteger index);
 @end
 
@@ -33,15 +34,18 @@ static CGFloat const kCellHeight = 44;
 - (instancetype)initWithItems:(NSArray <NSDictionary *>*)array
                         width:(CGFloat)width
              triangleLocation:(CGPoint)point
+                       window:(UIWindow *)window
                        action:(void(^)(NSInteger index))action
 {
     if (array.count == 0) return nil;
     if (self = [super init]) {
-        // 用 keyWindow 的实际 bounds 而不是 [UIScreen mainScreen].bounds——后者是竖屏原生
-        // 宽度,不随界面方向刷新,iPad 横屏下遮罩和下面的菜单锚点都会按错误的窄宽度算,
-        // 跟已经移到真实横屏右边缘的触发按钮脱节。
-        UIWindow *keyWin = [UIApplication sharedApplication].keyWindow;
-        self.frame = keyWin ? keyWin.bounds : [UIScreen mainScreen].bounds;
+        // 用触发按钮所在 window 的实际 bounds 而不是 [UIScreen mainScreen].bounds——后者是
+        // 竖屏原生宽度,不随界面方向刷新,iPad 横屏下遮罩和下面的菜单锚点都会按错误的窄宽度算,
+        // 跟已经移到真实横屏右边缘的触发按钮脱节。调用方只传一次 window(通常是按钮自己的
+        // .window),这里和 show 里都直接用它,不再各自独立查一遍 keyWindow。
+        UIWindow *hostWindow = window ?: [UIApplication sharedApplication].keyWindow;
+        self.hostWindow = hostWindow;
+        self.frame = hostWindow ? hostWindow.bounds : [UIScreen mainScreen].bounds;
         self.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
         self.alpha = 0;
         _tableData = [array copy];
@@ -77,8 +81,9 @@ static CGFloat const kCellHeight = 44;
         // 呼吸),两侧各留至少 5pt 边距;iPad 横屏/分屏下用真实 window 宽度兜底,
         // 不再锚死在竖屏 SCREEN_WIDTH 上。
         CGFloat menuRightX = MIN(point.x + 25, winW - 5);
+        // 三角尖点也要收进菜单的水平范围内,否则触发按钮太贴边时三角会画到菜单外面去。
+        _trianglePoint.x = MIN(MAX(point.x, menuRightX - finalWidth + 10), menuRightX - 10);
         CGFloat menuX = MAX(menuRightX - finalWidth, 5);
-        menuRightX = menuX + finalWidth;
 
         // 创建tableView
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(menuX, point.y + 10, finalWidth, kCellHeight * array.count) style:UITableViewStylePlain];
@@ -99,9 +104,10 @@ static CGFloat const kCellHeight = 44;
 + (void)showWithItems:(NSArray <NSDictionary *>*)array
                 width:(CGFloat)width
      triangleLocation:(CGPoint)point
+               window:(UIWindow *)window
                action:(void(^)(NSInteger index))action
 {
-    WKPopMenuView *view = [[WKPopMenuView alloc] initWithItems:array width:width triangleLocation:point action:action];
+    WKPopMenuView *view = [[WKPopMenuView alloc] initWithItems:array width:width triangleLocation:point window:window action:action];
     [view show];
 }
 
@@ -119,7 +125,7 @@ static CGFloat const kCellHeight = 44;
 
 #pragma mark - show or hide
 - (void)show {
-    [[UIApplication sharedApplication].keyWindow addSubview:self];
+    [(self.hostWindow ?: [UIApplication sharedApplication].keyWindow) addSubview:self];
     // anchorPoint = (1,0): position.x 即菜单右边缘;y 即菜单顶边。
     // 用 menu 自己 frame 的右边缘而不是 SCREEN_WIDTH,确保旋转后菜单仍紧贴三角尖点。
     _tableView.layer.position = CGPointMake(CGRectGetMaxX(_tableView.frame), _trianglePoint.y + 10);

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
@@ -354,7 +354,7 @@
     _chevronView.contentMode = UIViewContentModeScaleAspectFit;
     _chevronView.frame = CGRectMake(0, 0, chevronSize, chevronSize);
 
-    CGFloat maxNameWidth = WKScreenWidth - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
+    CGFloat maxNameWidth = self.view.lim_width - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
     _spaceNameLabel.text = self._title ?: [WKApp shared].config.appName;
     [_spaceNameLabel sizeToFit];
     if (_spaceNameLabel.lim_width > maxNameWidth) {
@@ -820,10 +820,9 @@
 }
 
 -(void) rightAddPressed {
-    
+
     NSArray<WKConversationAddItem*> *items = [[WKApp shared] invokes:WKPOINT_CATEGORY_CONVERSATION_ADD param:nil];
-    
-    CGFloat statusHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
+
     NSMutableArray *itemDicts = [NSMutableArray array];
     if(items && items.count>0) {
         for (WKConversationAddItem *item in items) {
@@ -833,7 +832,16 @@
             }];
         }
     }
-    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(WKScreenWidth-30, self.navigationController.navigationBar.lim_height + statusHeight-4.0f) action:^(NSInteger index) {
+    // 锚点用"+"按钮自身在 window 坐标里的位置,而不是手算 navBar.height + statusBar.height——
+    // 后者用的是不随旋转刷新的 statusBarFrame 以及可能被隐藏的系统 navigationBar 高度,
+    // iPad 横屏/分屏下会和真正按钮位置差出一个状态栏/导航栏量级。三角尖点对齐按钮下边缘
+    // 外侧 2pt(原逻辑是导航栏下方 -4,视觉位置基本一致,但是现在跟着按钮走)。
+    UIView *addBtn = [self.rightAddItem viewWithTag:8888];
+    CGRect addBtnFrameInWindow = addBtn ? [addBtn convertRect:addBtn.bounds toView:nil] : CGRectZero;
+    CGFloat anchorX = addBtn ? CGRectGetMidX(addBtnFrameInWindow) : WKScreenWidth - 30;
+    CGFloat anchorY = addBtn ? CGRectGetMaxY(addBtnFrameInWindow) + 2.0f
+                             : self.navigationController.navigationBar.lim_height + [[UIApplication sharedApplication] statusBarFrame].size.height - 4.0f;
+    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(anchorX, anchorY) action:^(NSInteger index) {
         WKConversationAddItem *item = [items objectAtIndex:index];
         if(item.onClick) {
             item.onClick();
@@ -860,7 +868,7 @@
 
         _spaceNameLabel.text = self._title;
         [_spaceNameLabel sizeToFit];
-        CGFloat maxNameWidth = WKScreenWidth - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
+        CGFloat maxNameWidth = self.view.lim_width - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
         if (_spaceNameLabel.lim_width > maxNameWidth) {
             _spaceNameLabel.lim_width = maxNameWidth;
         }
@@ -1257,6 +1265,14 @@
 // (WKNavigationBar 自己没有 layoutSubviews,宽度和 title/rightView 位置都是一次性算好的)。
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    if (!coordinator) {
+        // 有些 iPad 分屏尺寸变化不带 transition coordinator,
+        // [nil animateAlongsideTransition:...] 是静默空操作,alongside block 永远不会跑,
+        // 必须在这里直接同步重新布局,不能只依赖下面的 alongside 路径。
+        [self wk_relayoutNavigationBarForWidth:size.width];
+        [self layoutFixedHeader];
+        return;
+    }
     __weak typeof(self) weakSelf = self;
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [weakSelf wk_relayoutNavigationBarForWidth:size.width];
@@ -1396,7 +1412,7 @@
 
 - (UIView *)networkErroView {
     if(!_networkErroView) {
-        _networkErroView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, WKScreenWidth, networkErrorViewHeight)];
+        _networkErroView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, self.view.lim_width, networkErrorViewHeight)];
         UIImageView *warnIcon = [[UIImageView alloc] initWithFrame:CGRectMake(20.0f, 0.0f, 26.0f, 26.0f)];
         [warnIcon setImage:[self imageName:@"ConversationList/Index/NetworkStatusFail"]];
         warnIcon.lim_top = _networkErroView.lim_height/2.0f - warnIcon.lim_height/2.0f;
@@ -2445,7 +2461,7 @@
 
 
 -(void) setupConversationTabView {
-    _conversationTabView = [[WKConversationTabView alloc] initWithFrame:CGRectMake(0, 0, WKScreenWidth, 44)];
+    _conversationTabView = [[WKConversationTabView alloc] initWithFrame:CGRectMake(0, 0, self.view.lim_width, 44)];
     _conversationTabView.selectedIndex = _conversationListVM.filterType;
 
     __weak typeof(self) weakSelf = self;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
@@ -836,12 +836,13 @@
     // 后者用的是不随旋转刷新的 statusBarFrame 以及可能被隐藏的系统 navigationBar 高度,
     // iPad 横屏/分屏下会和真正按钮位置差出一个状态栏/导航栏量级。三角尖点对齐按钮下边缘
     // 外侧 2pt(原逻辑是导航栏下方 -4,视觉位置基本一致,但是现在跟着按钮走)。
+    // addBtn 就是触发这个 action 的按钮本身(tag 8888,见 setupRightItems),必然存在,
+    // 不需要 nil 兜底分支。
     UIView *addBtn = [self.rightAddItem viewWithTag:8888];
-    CGRect addBtnFrameInWindow = addBtn ? [addBtn convertRect:addBtn.bounds toView:nil] : CGRectZero;
-    CGFloat anchorX = addBtn ? CGRectGetMidX(addBtnFrameInWindow) : WKScreenWidth - 30;
-    CGFloat anchorY = addBtn ? CGRectGetMaxY(addBtnFrameInWindow) + 2.0f
-                             : self.navigationController.navigationBar.lim_height + [[UIApplication sharedApplication] statusBarFrame].size.height - 4.0f;
-    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(anchorX, anchorY) action:^(NSInteger index) {
+    CGRect addBtnFrameInWindow = [addBtn convertRect:addBtn.bounds toView:nil];
+    CGFloat anchorX = CGRectGetMidX(addBtnFrameInWindow);
+    CGFloat anchorY = CGRectGetMaxY(addBtnFrameInWindow) + 2.0f;
+    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(anchorX, anchorY) window:addBtn.window action:^(NSInteger index) {
         WKConversationAddItem *item = [items objectAtIndex:index];
         if(item.onClick) {
             item.onClick();
@@ -850,6 +851,13 @@
 }
 
 -(void) refreshTitle{
+    [self refreshTitleForWidth:self.view.lim_width];
+}
+
+// viewWillTransitionToSize 的 nil-coordinator 分支需要在 self.view.bounds 更新到目标宽度
+// 之前就同步刷新 leftView(space 胶囊),这里不能再读 self.view.lim_width(旧值),必须让
+// 调用方显式传入目标宽度。
+-(void) refreshTitleForWidth:(CGFloat)viewWidth {
     [self.connectLock lock];
 
     if (self.currentSpaceName && self.currentSpaceName.length > 0) {
@@ -868,7 +876,7 @@
 
         _spaceNameLabel.text = self._title;
         [_spaceNameLabel sizeToFit];
-        CGFloat maxNameWidth = self.view.lim_width - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
+        CGFloat maxNameWidth = viewWidth - 16 - avatarSize - gap * 2 - chevronSize - hPad * 2 - 120;
         if (_spaceNameLabel.lim_width > maxNameWidth) {
             _spaceNameLabel.lim_width = maxNameWidth;
         }
@@ -1234,27 +1242,34 @@
 // 搜索栏/tab 栏/固定头部容器会停在竖屏宽度不铺满。改用 self.view.lim_width(旋转后
 // 会随 viewWillTransitionToSize 触发的重新布局实时更新)。
 -(void) layoutFixedHeader {
+    [self layoutFixedHeaderForSize:self.view.bounds.size];
+}
+
+// viewWillTransitionToSize 的 nil-coordinator 分支在 self.view.bounds 还没更新到目标尺寸时
+// 就要同步布局,这时不能再读 self.view.lim_width/lim_height(读到的是旋转前的旧值),
+// 必须让调用方把目标 size 显式传进来。
+-(void) layoutFixedHeaderForSize:(CGSize)size {
     CGFloat navBottom = self.navigationBar.lim_bottom;
     CGFloat y = 0;
 
     // 搜索栏（左右 15pt 间距）
     UIView *searchbar = [_fixedHeaderContainer viewWithTag:9990];
     if (searchbar && !searchbar.hidden) {
-        searchbar.frame = CGRectMake(15, y + 6, self.view.lim_width - 30, 36);
+        searchbar.frame = CGRectMake(15, y + 6, size.width - 30, 36);
         y = searchbar.lim_bottom + 6;
     }
 
     // tab 栏
     if (_conversationTabView) {
-        _conversationTabView.frame = CGRectMake(0, y, self.view.lim_width, 44);
+        _conversationTabView.frame = CGRectMake(0, y, size.width, 44);
         y = _conversationTabView.lim_bottom;
     }
 
-    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, self.view.lim_width, y);
+    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, size.width, y);
 
     // 调整 tableView 位置到固定头部下方
     CGFloat tableTop = _fixedHeaderContainer.lim_bottom;
-    self.tableView.frame = CGRectMake(0, tableTop, self.view.lim_width, self.view.lim_height - tableTop);
+    self.tableView.frame = CGRectMake(0, tableTop, size.width, size.height - tableTop);
 }
 
 // iPad 支持分屏,系统不允许通过 supportedInterfaceOrientations 锁方向,只能老实做旋转
@@ -1269,14 +1284,19 @@
         // 有些 iPad 分屏尺寸变化不带 transition coordinator,
         // [nil animateAlongsideTransition:...] 是静默空操作,alongside block 永远不会跑,
         // 必须在这里直接同步重新布局,不能只依赖下面的 alongside 路径。
+        // 注意: 这个分支跑的时候 self.view.bounds 还没更新到 size,不能再让
+        // layoutFixedHeader/refreshTitle 内部去读 self.view.lim_width/lim_height(读到
+        // 的是旋转前的旧值),必须用 size 显式传入的宽高版本。
         [self wk_relayoutNavigationBarForWidth:size.width];
-        [self layoutFixedHeader];
+        [self layoutFixedHeaderForSize:size];
+        [self refreshTitleForWidth:size.width];
         return;
     }
     __weak typeof(self) weakSelf = self;
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [weakSelf wk_relayoutNavigationBarForWidth:size.width];
-        [weakSelf layoutFixedHeader];
+        [weakSelf layoutFixedHeaderForSize:size];
+        [weakSelf refreshTitleForWidth:size.width];
     } completion:nil];
 }
 

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
@@ -518,7 +518,8 @@
     // 会话)时不保证会触发(iOS 已知问题, rdar://24277475),压栈期间如果发生了尺寸变化,
     // 只靠那个回调不会跟着重新布局,返回时 header/tab栏/导航栏就可能还停在旧宽度。
     // 这里每次页面可见都按当前宽度重新校正一遍,不再只依赖旋转回调这一条路径。
-    [self wk_relayoutNavigationBarForWidth:self.view.lim_width];
+    // (rdar 那条我没有实测验证;不过这个兜底本身不依赖它成立——重复校正是幂等的。)
+    [self.navigationBar wk_relayoutForWidth:self.view.lim_width];
     [self layoutFixedHeader];
 
     [self refreshTitle];
@@ -736,7 +737,7 @@
         addBtn.frame = CGRectMake(0, 0, btnSize, btnSize);
         [addBtn setImage:[self createPlusImage] forState:UIControlStateNormal];
         addBtn.tintColor = [WKApp shared].config.navBarButtonColor;
-        [addBtn addTarget:self action:@selector(rightAddPressed) forControlEvents:UIControlEventTouchUpInside];
+        [addBtn addTarget:self action:@selector(rightAddPressed:) forControlEvents:UIControlEventTouchUpInside];
 
         _rightAddItem = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 200, itemH)];
         [_rightAddItem addSubview:self.signalContainerView];
@@ -819,7 +820,7 @@
     self.rightView = rightItem;
 }
 
--(void) rightAddPressed {
+-(void) rightAddPressed:(UIButton *)sender {
 
     NSArray<WKConversationAddItem*> *items = [[WKApp shared] invokes:WKPOINT_CATEGORY_CONVERSATION_ADD param:nil];
 
@@ -834,15 +835,15 @@
     }
     // 锚点用"+"按钮自身在 window 坐标里的位置,而不是手算 navBar.height + statusBar.height——
     // 后者用的是不随旋转刷新的 statusBarFrame 以及可能被隐藏的系统 navigationBar 高度,
-    // iPad 横屏/分屏下会和真正按钮位置差出一个状态栏/导航栏量级。三角尖点对齐按钮下边缘
+    // 分屏/横屏下会和真正按钮位置差出一个状态栏/导航栏量级。三角尖点对齐按钮下边缘
     // 外侧 2pt(原逻辑是导航栏下方 -4,视觉位置基本一致,但是现在跟着按钮走)。
-    // addBtn 就是触发这个 action 的按钮本身(tag 8888,见 setupRightItems),必然存在,
-    // 不需要 nil 兜底分支。
-    UIView *addBtn = [self.rightAddItem viewWithTag:8888];
-    CGRect addBtnFrameInWindow = [addBtn convertRect:addBtn.bounds toView:nil];
-    CGFloat anchorX = CGRectGetMidX(addBtnFrameInWindow);
-    CGFloat anchorY = CGRectGetMaxY(addBtnFrameInWindow) + 2.0f;
-    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(anchorX, anchorY) window:addBtn.window action:^(NSInteger index) {
+    // 直接用 sender(就是被点的那个"+"按钮),不再回头按 tag 8888 去 rightAddItem 里捞:
+    // rightAddItem 是懒加载 getter,万一 _rightAddItem 已被释放,那条路会重建一份没上屏、
+    // window 为 nil 的层级,菜单会静默锚到 window 左上角而不是响亮地失败。
+    CGRect senderFrameInWindow = [sender convertRect:sender.bounds toView:nil];
+    CGFloat anchorX = CGRectGetMidX(senderFrameInWindow);
+    CGFloat anchorY = CGRectGetMaxY(senderFrameInWindow) + 2.0f;
+    [WKPopMenuView showWithItems:itemDicts width:140.0f triangleLocation:CGPointMake(anchorX, anchorY) window:sender.window action:^(NSInteger index) {
         WKConversationAddItem *item = [items objectAtIndex:index];
         if(item.onClick) {
             item.onClick();
@@ -1237,10 +1238,16 @@
 }
 
 /// 重新布局固定头部（搜索栏 + tabView）并调整 tableView 的 frame
-// 注意: 这里原先用 WKScreenWidth([UIScreen mainScreen].bounds.size.width) 算宽度——
-// iOS 8 之后 UIScreen.bounds 不随界面方向旋转,永远是竖屏原始宽度,iPad 横屏时
-// 搜索栏/tab 栏/固定头部容器会停在竖屏宽度不铺满。改用 self.view.lim_width(旋转后
-// 会随 viewWillTransitionToSize 触发的重新布局实时更新)。
+// 注意: 这里原先用 WKScreenWidth([UIScreen mainScreen].bounds.size.width) 算宽度,改成了
+// 用本 VC 自己 view 的宽度。两条理由,都跟"方向"无关:
+//   1. 屏幕不等于窗口。Info.plist 没有 UIRequiresFullScreen,所以 Split View / Slide Over /
+//      Stage Manager 下 app 只占屏幕的一部分,屏幕宽度会高估可用宽度。要铺满的是 window/view,
+//      不是 screen。
+//   2. 这段布局原先只在 viewDidLoad 链路跑过一次,宽度被烘进各子视图的 frame 后再没重算过——
+//      这是 #85 的直接成因(旋转/分屏后没人重新布局),跟宽度取自哪里无关。
+// 顺便纠正一个容易写反的点: [UIScreen mainScreen].bounds 自 iOS 8 起"是"跟随界面方向的,
+// nativeBounds / fixedCoordinateSpace 才是方向无关的那两个;WKScreenWidth 也是宏,每次调用
+// 都会重新求值。所以别再写"UIScreen.bounds 被冻结在竖屏宽度"这类归因。
 -(void) layoutFixedHeader {
     [self layoutFixedHeaderForSize:self.view.bounds.size];
 }
@@ -1274,45 +1281,31 @@
 
 // iPad 支持分屏,系统不允许通过 supportedInterfaceOrientations 锁方向,只能老实做旋转
 // 自适应布局。这个页面原本没有任何旋转处理:固定头部(搜索栏+tab栏)只在 viewDidLoad
-// 链路里布局过一次,旋转后不会再重新走 layoutFixedHeader,加上其内部又用了不随方向变化
-// 的 WKScreenWidth(见上面 layoutFixedHeader 的注释),导致横屏时除了系统 UITabBar
-// 之外的内容全部停在竖屏宽度。这里补上旋转回调,同时顺带修一下 navigationBar 的同类问题
-// (WKNavigationBar 自己没有 layoutSubviews,宽度和 title/rightView 位置都是一次性算好的)。
+// 链路里布局过一次,旋转或分屏尺寸变化后没有任何代码再重新布局它,宽度就一直停在首次
+// 布局时的值(见上面 layoutFixedHeader 的注释)。这里补上旋转回调,同时顺带修一下
+// navigationBar 的同类问题(WKNavigationBar 自己没有 layoutSubviews,宽度和
+// title/leftView/rightView 位置都是一次性算好的)。
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     if (!coordinator) {
-        // 有些 iPad 分屏尺寸变化不带 transition coordinator,
-        // [nil animateAlongsideTransition:...] 是静默空操作,alongside block 永远不会跑,
-        // 必须在这里直接同步重新布局,不能只依赖下面的 alongside 路径。
+        // 防御性分支,未验证: UIKit 把 coordinator 声明为 nonnull,实测的旋转和分屏都带
+        // coordinator,所以这条路走不到。留着是因为 [nil animateAlongsideTransition:...]
+        // 是静默空操作——万一真拿到 nil,下面的 alongside block 永远不会跑,页面就不重排了。
+        // 别把这里当成已验证过的路径。
         // 注意: 这个分支跑的时候 self.view.bounds 还没更新到 size,不能再让
         // layoutFixedHeader/refreshTitle 内部去读 self.view.lim_width/lim_height(读到
         // 的是旋转前的旧值),必须用 size 显式传入的宽高版本。
-        [self wk_relayoutNavigationBarForWidth:size.width];
+        [self.navigationBar wk_relayoutForWidth:size.width];
         [self layoutFixedHeaderForSize:size];
         [self refreshTitleForWidth:size.width];
         return;
     }
     __weak typeof(self) weakSelf = self;
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [weakSelf wk_relayoutNavigationBarForWidth:size.width];
+        [weakSelf.navigationBar wk_relayoutForWidth:size.width];
         [weakSelf layoutFixedHeaderForSize:size];
         [weakSelf refreshTitleForWidth:size.width];
     } completion:nil];
-}
-
-// navigationBar 的 title/rightView 位置都是在各自 setter 里按"当时"的 self.lim_width 算好
-// 就定死,不会随外部 frame 变化自动重排。这里只改它自己的宽度,再用同一份值重新触发一遍
-// title/rightView 的 setter,逼它们按新宽度重新居中/靠右——不在这里重复实现 WKNavigationBar
-// 内部那套定位公式,避免两处代码各算一遍、以后改了一处忘了另一处。
-- (void)wk_relayoutNavigationBarForWidth:(CGFloat)width {
-    CGRect frame = self.navigationBar.frame;
-    if (frame.size.width == width) return;
-    frame.size.width = width;
-    self.navigationBar.frame = frame;
-    self.navigationBar.title = self.navigationBar.title;
-    if (self.navigationBar.rightView) {
-        self.navigationBar.rightView = self.navigationBar.rightView;
-    }
 }
 
 - (WKConversationListTableView *)tableView{
@@ -1432,7 +1425,7 @@
 
 - (UIView *)networkErroView {
     if(!_networkErroView) {
-        _networkErroView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, self.view.lim_width, networkErrorViewHeight)];
+        _networkErroView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, WKScreenWidth, networkErrorViewHeight)];
         UIImageView *warnIcon = [[UIImageView alloc] initWithFrame:CGRectMake(20.0f, 0.0f, 26.0f, 26.0f)];
         [warnIcon setImage:[self imageName:@"ConversationList/Index/NetworkStatusFail"]];
         warnIcon.lim_top = _networkErroView.lim_height/2.0f - warnIcon.lim_height/2.0f;

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationListVC.m
@@ -514,6 +514,13 @@
 -(void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
+    // 兜底: viewWillTransitionToSize 在本 VC 被压在导航栈里(不是最顶层,比如打开了某个
+    // 会话)时不保证会触发(iOS 已知问题, rdar://24277475),压栈期间如果发生了尺寸变化,
+    // 只靠那个回调不会跟着重新布局,返回时 header/tab栏/导航栏就可能还停在旧宽度。
+    // 这里每次页面可见都按当前宽度重新校正一遍,不再只依赖旋转回调这一条路径。
+    [self wk_relayoutNavigationBarForWidth:self.view.lim_width];
+    [self layoutFixedHeader];
+
     [self refreshTitle];
     [self hiddenRightItem:NO];
 
@@ -1197,10 +1204,10 @@
 /// 创建固定在顶部的搜索栏容器（不随 tableView 滚动）
 -(void) setupFixedHeader {
     CGFloat navBottom = self.navigationBar.lim_bottom;
-    _fixedHeaderContainer = [[UIView alloc] initWithFrame:CGRectMake(0, navBottom, WKScreenWidth, 0)];
+    _fixedHeaderContainer = [[UIView alloc] initWithFrame:CGRectMake(0, navBottom, self.view.lim_width, 0)];
     _fixedHeaderContainer.backgroundColor = [WKApp shared].config.backgroundColor;
 
-    WKSearchbarView *searchbar = [[WKSearchbarView alloc] initWithFrame:CGRectMake(15, 6, WKScreenWidth - 30, 36)];
+    WKSearchbarView *searchbar = [[WKSearchbarView alloc] initWithFrame:CGRectMake(15, 6, self.view.lim_width - 30, 36)];
     searchbar.placeholder = LLang(@"搜索");
     searchbar.layer.masksToBounds = YES;
     searchbar.onClick = ^{
@@ -1214,6 +1221,10 @@
 }
 
 /// 重新布局固定头部（搜索栏 + tabView）并调整 tableView 的 frame
+// 注意: 这里原先用 WKScreenWidth([UIScreen mainScreen].bounds.size.width) 算宽度——
+// iOS 8 之后 UIScreen.bounds 不随界面方向旋转,永远是竖屏原始宽度,iPad 横屏时
+// 搜索栏/tab 栏/固定头部容器会停在竖屏宽度不铺满。改用 self.view.lim_width(旋转后
+// 会随 viewWillTransitionToSize 触发的重新布局实时更新)。
 -(void) layoutFixedHeader {
     CGFloat navBottom = self.navigationBar.lim_bottom;
     CGFloat y = 0;
@@ -1221,21 +1232,51 @@
     // 搜索栏（左右 15pt 间距）
     UIView *searchbar = [_fixedHeaderContainer viewWithTag:9990];
     if (searchbar && !searchbar.hidden) {
-        searchbar.frame = CGRectMake(15, y + 6, WKScreenWidth - 30, 36);
+        searchbar.frame = CGRectMake(15, y + 6, self.view.lim_width - 30, 36);
         y = searchbar.lim_bottom + 6;
     }
 
     // tab 栏
     if (_conversationTabView) {
-        _conversationTabView.frame = CGRectMake(0, y, WKScreenWidth, 44);
+        _conversationTabView.frame = CGRectMake(0, y, self.view.lim_width, 44);
         y = _conversationTabView.lim_bottom;
     }
 
-    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, WKScreenWidth, y);
+    _fixedHeaderContainer.frame = CGRectMake(0, navBottom, self.view.lim_width, y);
 
     // 调整 tableView 位置到固定头部下方
     CGFloat tableTop = _fixedHeaderContainer.lim_bottom;
     self.tableView.frame = CGRectMake(0, tableTop, self.view.lim_width, self.view.lim_height - tableTop);
+}
+
+// iPad 支持分屏,系统不允许通过 supportedInterfaceOrientations 锁方向,只能老实做旋转
+// 自适应布局。这个页面原本没有任何旋转处理:固定头部(搜索栏+tab栏)只在 viewDidLoad
+// 链路里布局过一次,旋转后不会再重新走 layoutFixedHeader,加上其内部又用了不随方向变化
+// 的 WKScreenWidth(见上面 layoutFixedHeader 的注释),导致横屏时除了系统 UITabBar
+// 之外的内容全部停在竖屏宽度。这里补上旋转回调,同时顺带修一下 navigationBar 的同类问题
+// (WKNavigationBar 自己没有 layoutSubviews,宽度和 title/rightView 位置都是一次性算好的)。
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak typeof(self) weakSelf = self;
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [weakSelf wk_relayoutNavigationBarForWidth:size.width];
+        [weakSelf layoutFixedHeader];
+    } completion:nil];
+}
+
+// navigationBar 的 title/rightView 位置都是在各自 setter 里按"当时"的 self.lim_width 算好
+// 就定死,不会随外部 frame 变化自动重排。这里只改它自己的宽度,再用同一份值重新触发一遍
+// title/rightView 的 setter,逼它们按新宽度重新居中/靠右——不在这里重复实现 WKNavigationBar
+// 内部那套定位公式,避免两处代码各算一遍、以后改了一处忘了另一处。
+- (void)wk_relayoutNavigationBarForWidth:(CGFloat)width {
+    CGRect frame = self.navigationBar.frame;
+    if (frame.size.width == width) return;
+    frame.size.width = width;
+    self.navigationBar.frame = frame;
+    self.navigationBar.title = self.navigationBar.title;
+    if (self.navigationBar.rightView) {
+        self.navigationBar.rightView = self.navigationBar.rightView;
+    }
 }
 
 - (WKConversationListTableView *)tableView{

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationTabView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationTabView.m
@@ -166,33 +166,41 @@ static CGFloat const kBadgeSize = 16.0f;
 }
 
 - (void)layoutBadges {
-    [self layoutTabButton:_followBtn badge:_followBadge];
-    [self layoutTabButton:_recentBtn badge:_recentBadge];
+    // 两个 tab 的标题要水平对称——titleEdgeInsets 的偏移量必须两侧一致,
+    // 否则只有一侧有未读 badge 时,该侧标题被 badge 顶开左偏,另一侧仍居中,
+    // "关注"/"最近"在各自半宽里的位置就对不齐(竖屏下可见,横屏更明显)。
+    // 取两侧 badge 占位宽度的最大值,两边都按同一个值退让;有 badge 的一侧
+    // badge 从真实标题右边缘贴上去,没 badge 的一侧标题微左移半格,但两边对齐。
+    CGFloat followExtra = [self badgeExtra:_followBadge];
+    CGFloat recentExtra = [self badgeExtra:_recentBadge];
+    CGFloat sharedExtra = MAX(followExtra, recentExtra);
+    CGFloat sharedOffset = -sharedExtra / 2.0f;
+
+    for (UIButton *btn in @[_followBtn, _recentBtn]) {
+        btn.titleEdgeInsets = UIEdgeInsetsMake(0, sharedOffset, 0, -sharedOffset);
+    }
+    [_followBtn layoutIfNeeded];
+    [_recentBtn layoutIfNeeded];
+
+    [self placeBadge:_followBadge onButton:_followBtn offset:sharedOffset];
+    [self placeBadge:_recentBadge onButton:_recentBtn offset:sharedOffset];
 }
 
-- (void)layoutTabButton:(UIButton *)btn badge:(UILabel *)badge {
-    // badge 占用宽度：用于 titleEdgeInsets 把"标题 + badge"整体居中。
-    CGFloat extra = 0;
-    if (!badge.hidden) {
-        [badge sizeToFit];
-        extra = 2 + MAX(badge.bounds.size.width + 6, kBadgeSize);
-    }
+- (CGFloat)badgeExtra:(UILabel *)badge {
+    if (badge.hidden) return 0.0f;
+    [badge sizeToFit];
+    return 2 + MAX(badge.bounds.size.width + 6, kBadgeSize);
+}
 
-    CGFloat offset = -extra / 2.0f;
-    btn.titleEdgeInsets = UIEdgeInsetsMake(0, offset, 0, -offset);
-    [btn layoutIfNeeded];
-
-    if (!badge.hidden) {
-        NSString *title = btn.titleLabel.text ?: @"";
-        UIFont *font = btn.titleLabel.font;
-        CGFloat textW = [title sizeWithAttributes:@{NSFontAttributeName: font}].width;
-        CGFloat titleRight = CGRectGetMidX(btn.frame) + offset + textW / 2.0f;
-        // badge 纵向跟"关注/最近"文字基线/中心齐平：button.titleLabel.centerY ≈ button.centerY，
-        // 直接以按钮中心为锚，不要再上移，否则视觉上漂在标题上方。
-        CGFloat textCenterY = CGRectGetMidY(btn.frame);
-        CGFloat badgeW = MAX(badge.bounds.size.width + 6, kBadgeSize);
-        badge.frame = CGRectMake(titleRight + 2, textCenterY - kBadgeSize / 2.0f, badgeW, kBadgeSize);
-    }
+- (void)placeBadge:(UILabel *)badge onButton:(UIButton *)btn offset:(CGFloat)offset {
+    if (badge.hidden) return;
+    NSString *title = btn.titleLabel.text ?: @"";
+    UIFont *font = btn.titleLabel.font;
+    CGFloat textW = [title sizeWithAttributes:@{NSFontAttributeName: font}].width;
+    CGFloat titleRight = CGRectGetMidX(btn.frame) + offset + textW / 2.0f;
+    CGFloat textCenterY = CGRectGetMidY(btn.frame);
+    CGFloat badgeW = MAX(badge.bounds.size.width + 6, kBadgeSize);
+    badge.frame = CGRectMake(titleRight + 2, textCenterY - kBadgeSize / 2.0f, badgeW, kBadgeSize);
 }
 
 #pragma mark - Actions

--- a/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationTabView.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/Sections/ConversationList/WKConversationTabView.m
@@ -166,41 +166,33 @@ static CGFloat const kBadgeSize = 16.0f;
 }
 
 - (void)layoutBadges {
-    // 两个 tab 的标题要水平对称——titleEdgeInsets 的偏移量必须两侧一致,
-    // 否则只有一侧有未读 badge 时,该侧标题被 badge 顶开左偏,另一侧仍居中,
-    // "关注"/"最近"在各自半宽里的位置就对不齐(竖屏下可见,横屏更明显)。
-    // 取两侧 badge 占位宽度的最大值,两边都按同一个值退让;有 badge 的一侧
-    // badge 从真实标题右边缘贴上去,没 badge 的一侧标题微左移半格,但两边对齐。
-    CGFloat followExtra = [self badgeExtra:_followBadge];
-    CGFloat recentExtra = [self badgeExtra:_recentBadge];
-    CGFloat sharedExtra = MAX(followExtra, recentExtra);
-    CGFloat sharedOffset = -sharedExtra / 2.0f;
+    [self layoutTabButton:_followBtn badge:_followBadge];
+    [self layoutTabButton:_recentBtn badge:_recentBadge];
+}
 
-    for (UIButton *btn in @[_followBtn, _recentBtn]) {
-        btn.titleEdgeInsets = UIEdgeInsetsMake(0, sharedOffset, 0, -sharedOffset);
+- (void)layoutTabButton:(UIButton *)btn badge:(UILabel *)badge {
+    // badge 占用宽度：用于 titleEdgeInsets 把"标题 + badge"整体居中。
+    CGFloat extra = 0;
+    if (!badge.hidden) {
+        [badge sizeToFit];
+        extra = 2 + MAX(badge.bounds.size.width + 6, kBadgeSize);
     }
-    [_followBtn layoutIfNeeded];
-    [_recentBtn layoutIfNeeded];
 
-    [self placeBadge:_followBadge onButton:_followBtn offset:sharedOffset];
-    [self placeBadge:_recentBadge onButton:_recentBtn offset:sharedOffset];
-}
+    CGFloat offset = -extra / 2.0f;
+    btn.titleEdgeInsets = UIEdgeInsetsMake(0, offset, 0, -offset);
+    [btn layoutIfNeeded];
 
-- (CGFloat)badgeExtra:(UILabel *)badge {
-    if (badge.hidden) return 0.0f;
-    [badge sizeToFit];
-    return 2 + MAX(badge.bounds.size.width + 6, kBadgeSize);
-}
-
-- (void)placeBadge:(UILabel *)badge onButton:(UIButton *)btn offset:(CGFloat)offset {
-    if (badge.hidden) return;
-    NSString *title = btn.titleLabel.text ?: @"";
-    UIFont *font = btn.titleLabel.font;
-    CGFloat textW = [title sizeWithAttributes:@{NSFontAttributeName: font}].width;
-    CGFloat titleRight = CGRectGetMidX(btn.frame) + offset + textW / 2.0f;
-    CGFloat textCenterY = CGRectGetMidY(btn.frame);
-    CGFloat badgeW = MAX(badge.bounds.size.width + 6, kBadgeSize);
-    badge.frame = CGRectMake(titleRight + 2, textCenterY - kBadgeSize / 2.0f, badgeW, kBadgeSize);
+    if (!badge.hidden) {
+        NSString *title = btn.titleLabel.text ?: @"";
+        UIFont *font = btn.titleLabel.font;
+        CGFloat textW = [title sizeWithAttributes:@{NSFontAttributeName: font}].width;
+        CGFloat titleRight = CGRectGetMidX(btn.frame) + offset + textW / 2.0f;
+        // badge 纵向跟"关注/最近"文字基线/中心齐平：button.titleLabel.centerY ≈ button.centerY，
+        // 直接以按钮中心为锚，不要再上移，否则视觉上漂在标题上方。
+        CGFloat textCenterY = CGRectGetMidY(btn.frame);
+        CGFloat badgeW = MAX(badge.bounds.size.width + 6, kBadgeSize);
+        badge.frame = CGRectMake(titleRight + 2, textCenterY - kBadgeSize / 2.0f, badgeW, kBadgeSize);
+    }
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
Closes #85

## What

iPad 横屏下，消息列表页的头部（搜索栏 / 分类 tab 行 / 导航栏）不能铺满整行，仍然按竖屏宽度显示；从其他页面（如打开一个会话）返回后同样会看到未铺满的状态。

## Why

- `setupFixedHeader` / `layoutFixedHeader` 依赖的 `WKScreenWidth` 宏取的是 `[UIScreen mainScreen].bounds.size.width`，从 iOS 8 起就被冻结在竖屏宽度，不随旋转变化，导致头部宽度计算始终按竖屏算。
- 该 VC 的重新布局原本只能靠 `viewWillTransitionToSize:withTransitionCoordinator:` 触发。但根据 Apple 已知问题 rdar://24277475，该回调在本 VC 不是导航栈最顶层控制器时（例如上面压了一个聊天页）不保证被调用，仅靠这一条路径无法覆盖所有场景。

## How

1. `setupFixedHeader` / `layoutFixedHeader` 改用 `self.view.lim_width`（跟随实际视图宽度），不再用被冻结的 `WKScreenWidth`。
2. 新增 `viewWillTransitionToSize:withTransitionCoordinator:` 覆盖，旋转时通过 `wk_relayoutNavigationBarForWidth:` + `layoutFixedHeader` 重新布局导航栏与固定头部。
3. `viewWillAppear:` 中同样执行一次上述重新布局，保证页面每次可见时都按当前宽度校正，不依赖旋转回调是否被调用。

## Checklist

- [x] Code compiles with no new warnings
- [ ] Linter and formatter pass
- [ ] Tests added/updated for the changes
- [ ] All tests pass locally
- [x] Rebased onto latest `main`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-reviewed the full diff from a reviewer's perspective

## Testing

- 本地执行 `xcodebuild -workspace OctoiOS.xcworkspace -scheme OctoContext -sdk iphonesimulator build`，编译通过。

## Breaking Changes

N/A
