### PR TITLE
fix(ios): probeLiveness 加并发 guard + 显式 cancel wsTask 与 sleep-inclusive 防抖

### DIFF
--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -155,6 +155,9 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 @property(nonatomic,assign) BOOL isShowScreenProtect; // 是否显示屏幕保护
 @property(nonatomic,strong) WKScreenProtectionView *screenProtectionView; // 屏幕保护view
 
+// appDidBecomeActive wakeup 探测的防抖时间戳（秒，since1970）。5 秒窗口内多次前台切换只探测一次。
+@property(nonatomic,assign) NSTimeInterval lastWakeupAt;
+
 
 
 @end
@@ -857,9 +860,19 @@ static WKApp *_instance;
     for (WKMessage *typingMsg in [[WKTypingManager shared] getAllTypingMessages]) {
         [[WKTypingManager shared] removeTypingByChannel:typingMsg.channel newMessage:nil];
     }
-    // 连接
-    if([[WKSDK shared] connectionManager].connectStatus == WKDisconnected  && [WKApp shared].isLogined) {
-        [[[WKSDK shared] connectionManager] connect];
+    // 回前台主动做一次短心跳探测：iOS 后台 NSTimer 冻结会让 WKConnectionManager 心跳停发，
+    // 服务端踢连接后本地状态机可能仍停在 WKConnected（假在线），从而错过 SDK 握手成功后的
+    // syncConversations，导致会话列表停在旧快照直到用户杀 app。这里无条件调用 wakeup:，
+    // 由 SDK 内部判断连接活性并在需要时触发重连 + 后续 syncConversations，行为对齐 web 端。
+    // 5 秒防抖：iOS 前后台快速切换（弹权限、Face ID、控件面板）会连发 appDidBecomeActive。
+    if([WKApp shared].isLogined) {
+        NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+        if(now - self.lastWakeupAt >= 5.0) {
+            self.lastWakeupAt = now;
+            [[[WKSDK shared] connectionManager] wakeup:2 complete:^(NSError *error) {
+                // wakeup 内部处理连接态与断连重连，握手成功后 SDK 自动跑 syncConversations。
+            }];
+        }
     }
     
     if([WKApp shared].config.darkModeWithSystem) {

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -17,7 +17,7 @@
 #import "WKLocalNotificationManager.h"
 #import "WKRealnameVerifyManager.h"
 #import <WuKongIMSDK/WuKongIMSDK.h>
-#import <QuartzCore/QuartzCore.h>
+#import <time.h>
 #import "WKMessageRegistry.h"
 #import "WKTextMessageCell.h"
 #import "WKEmojiPanel.h"
@@ -156,8 +156,11 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 @property(nonatomic,assign) BOOL isShowScreenProtect; // 是否显示屏幕保护
 @property(nonatomic,strong) WKScreenProtectionView *screenProtectionView; // 屏幕保护view
 
-// appDidBecomeActive liveness probe 的防抖时间戳（单调时钟，秒）。5 秒窗口内多次前台切换只探测一次。
-@property(nonatomic,assign) CFTimeInterval lastWakeupAt;
+// appDidBecomeActive liveness probe 的防抖时间戳（sleep-inclusive monotonic 纳秒 since boot）。
+// 5 秒窗口内多次前台切换只探测一次。用 CLOCK_MONOTONIC_RAW（sleep-inclusive）而非
+// CACurrentMediaTime()（后者是 CLOCK_UPTIME_RAW，锁屏/睡眠期间不推进——长锁屏后 delta
+// 可能仍 < 5s，会错误抑制回前台的探测）。
+@property(nonatomic,assign) uint64_t lastWakeupAtNs;
 
 
 
@@ -864,13 +867,14 @@ static WKApp *_instance;
     // 回前台主动做一次连接活性探测：iOS 后台 NSTimer 冻结会让 WKConnectionManager 心跳停发，
     // 服务端踢连接后本地状态机可能仍停在 WKConnected（假在线），从而错过 SDK 握手成功后的
     // syncConversations，会话列表停在旧快照直到用户杀 app。走 SDK 的 probeLiveness:——它在
-    // WKConnected 时主动发 ping 等 pong，超时则强制断开重连；在 WKConnecting/WKPullingOffline
-    // 期间 early-return 不打扰 in-flight 握手/离线拉取。行为对齐 web 端的 visibilitychange。
-    // 5 秒防抖用 CACurrentMediaTime()（单调时钟），避免设备时钟被回拨时抑制探测。
+    // WKConnected 时主动发 ping 等 pong，超时且 socket/状态未被并发替换时显式 cancel wsTask
+    // 并强制重连；在 WKConnecting/WKPullingOffline 期间 early-return 不打扰 in-flight。
+    // 5 秒防抖用 CLOCK_MONOTONIC_RAW（sleep-inclusive，锁屏期间也推进），避免长锁屏后
+    // delta < 5s 抑制探测；也避免设备时钟被回拨/前拨造成误判。
     if([WKApp shared].isLogined) {
-        CFTimeInterval now = CACurrentMediaTime();
-        if(now - self.lastWakeupAt >= 5.0) {
-            self.lastWakeupAt = now;
+        uint64_t nowNs = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+        if(nowNs - self.lastWakeupAtNs >= 5ULL * NSEC_PER_SEC) {
+            self.lastWakeupAtNs = nowNs;
             [[[WKSDK shared] connectionManager] probeLiveness:2 complete:^(BOOL alive, NSError *error) {
                 if(error) {
                     NSLog(@"WKApp probeLiveness on foreground reported: alive=%d error=%@", alive, error);

--- a/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
+++ b/Modules/WuKongBase/WuKongBase/Classes/WKApp.m
@@ -17,6 +17,7 @@
 #import "WKLocalNotificationManager.h"
 #import "WKRealnameVerifyManager.h"
 #import <WuKongIMSDK/WuKongIMSDK.h>
+#import <QuartzCore/QuartzCore.h>
 #import "WKMessageRegistry.h"
 #import "WKTextMessageCell.h"
 #import "WKEmojiPanel.h"
@@ -155,8 +156,8 @@ typedef void(^WKOnComplete)(id data,NSError *error);
 @property(nonatomic,assign) BOOL isShowScreenProtect; // 是否显示屏幕保护
 @property(nonatomic,strong) WKScreenProtectionView *screenProtectionView; // 屏幕保护view
 
-// appDidBecomeActive wakeup 探测的防抖时间戳（秒，since1970）。5 秒窗口内多次前台切换只探测一次。
-@property(nonatomic,assign) NSTimeInterval lastWakeupAt;
+// appDidBecomeActive liveness probe 的防抖时间戳（单调时钟，秒）。5 秒窗口内多次前台切换只探测一次。
+@property(nonatomic,assign) CFTimeInterval lastWakeupAt;
 
 
 
@@ -860,17 +861,20 @@ static WKApp *_instance;
     for (WKMessage *typingMsg in [[WKTypingManager shared] getAllTypingMessages]) {
         [[WKTypingManager shared] removeTypingByChannel:typingMsg.channel newMessage:nil];
     }
-    // 回前台主动做一次短心跳探测：iOS 后台 NSTimer 冻结会让 WKConnectionManager 心跳停发，
+    // 回前台主动做一次连接活性探测：iOS 后台 NSTimer 冻结会让 WKConnectionManager 心跳停发，
     // 服务端踢连接后本地状态机可能仍停在 WKConnected（假在线），从而错过 SDK 握手成功后的
-    // syncConversations，导致会话列表停在旧快照直到用户杀 app。这里无条件调用 wakeup:，
-    // 由 SDK 内部判断连接活性并在需要时触发重连 + 后续 syncConversations，行为对齐 web 端。
-    // 5 秒防抖：iOS 前后台快速切换（弹权限、Face ID、控件面板）会连发 appDidBecomeActive。
+    // syncConversations，会话列表停在旧快照直到用户杀 app。走 SDK 的 probeLiveness:——它在
+    // WKConnected 时主动发 ping 等 pong，超时则强制断开重连；在 WKConnecting/WKPullingOffline
+    // 期间 early-return 不打扰 in-flight 握手/离线拉取。行为对齐 web 端的 visibilitychange。
+    // 5 秒防抖用 CACurrentMediaTime()（单调时钟），避免设备时钟被回拨时抑制探测。
     if([WKApp shared].isLogined) {
-        NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+        CFTimeInterval now = CACurrentMediaTime();
         if(now - self.lastWakeupAt >= 5.0) {
             self.lastWakeupAt = now;
-            [[[WKSDK shared] connectionManager] wakeup:2 complete:^(NSError *error) {
-                // wakeup 内部处理连接态与断连重连，握手成功后 SDK 自动跑 syncConversations。
+            [[[WKSDK shared] connectionManager] probeLiveness:2 complete:^(BOOL alive, NSError *error) {
+                if(error) {
+                    NSLog(@"WKApp probeLiveness on foreground reported: alive=%d error=%@", alive, error);
+                }
             }];
         }
     }

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.h
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.h
@@ -109,6 +109,21 @@ typedef enum : NSUInteger {
  */
 -(void) wakeup:(NSTimeInterval)timeout complete:(void(^__nullable)(NSError * __nullable error))complete;
 
+/**
+ 主动探测连接活性（用于前台恢复等场景，能识别本地状态机停在 WKConnected 但服务端已踢的
+ "假在线"）。
+ - WKConnected：发送 ping，在 timeout 内若 lastMsgTimeInterval 未推进则视为假在线，
+   走 handleWSDisconnectWithError: 强制断开 + 自动重连（触发 SDK 内部 syncConversations）。
+ - WKConnecting / WKPullingOffline：握手或离线拉取 in flight，不打扰，直接回调 alive=NO。
+ - WKDisconnected / WKNoConnect：直接 connect。
+ 与 wakeup: 的区别：wakeup: 在 WKConnected 时直接 early return，无法识别假在线；
+ probeLiveness: 主动发 ping 验证响应。
+ @param timeout ping 等待响应的超时（秒），建议 2 秒
+ @param complete 完成回调，alive=YES 表示连接活着（收到了 pong 或其他入站消息），
+                 alive=NO 表示状态机在 in-flight 状态或探测超时已触发重连
+ */
+-(void) probeLiveness:(NSTimeInterval)timeout complete:(void(^__nullable)(BOOL alive, NSError * __nullable error))complete;
+
 
 
 @end

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.h
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.h
@@ -112,15 +112,19 @@ typedef enum : NSUInteger {
 /**
  主动探测连接活性（用于前台恢复等场景，能识别本地状态机停在 WKConnected 但服务端已踢的
  "假在线"）。
- - WKConnected：发送 ping，在 timeout 内若 lastMsgTimeInterval 未推进则视为假在线，
-   走 handleWSDisconnectWithError: 强制断开 + 自动重连（触发 SDK 内部 syncConversations）。
+ - WKConnected：发送 ping，在 timeout 内若 lastMsgTimeInterval 未推进，且被 probe 的
+   wsTask 与 connectStatus 未被并发路径改动，则显式 cancel 该 wsTask 并走
+   handleWSDisconnectWithError: 强制断开 + 自动重连（触发 SDK 内部 syncConversations）。
+   若 timeout 时发现 socket 已被并发 reconnect 替换 / 状态已变，则让那条生命周期继续，
+   不做二次 backoff。
  - WKConnecting / WKPullingOffline：握手或离线拉取 in flight，不打扰，直接回调 alive=NO。
  - WKDisconnected / WKNoConnect：直接 connect。
  与 wakeup: 的区别：wakeup: 在 WKConnected 时直接 early return，无法识别假在线；
  probeLiveness: 主动发 ping 验证响应。
+ 契约：complete 回调统一 hop 到 main queue（无论 case A/B/C），调用方可以放心访问 UI 状态。
  @param timeout ping 等待响应的超时（秒），建议 2 秒
- @param complete 完成回调，alive=YES 表示连接活着（收到了 pong 或其他入站消息），
-                 alive=NO 表示状态机在 in-flight 状态或探测超时已触发重连
+ @param complete 完成回调（main queue），alive=YES 表示连接活着（收到了 pong 或其他入站消息），
+                 alive=NO 表示状态机在 in-flight 状态、被并发路径覆盖，或探测超时已触发重连
  */
 -(void) probeLiveness:(NSTimeInterval)timeout complete:(void(^__nullable)(BOOL alive, NSError * __nullable error))complete;
 

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
@@ -1077,10 +1077,15 @@ didCompleteWithError:(NSError *)error {
             // 顺序参考 teardownWS: 先把 self.wsTask 置 nil，再 cancel，让延迟的
             // didClose:/didCompleteWithError: 走 `task != self.wsTask` 早返，不会重复走
             // handleWSDisconnect（幂等）。
+            // close code 用 GoingAway (1001) 与 teardownWS 一致；1006 (AbnormalClosure) 是
+            // RFC 6455 保留码，endpoint 不允许在 Close frame 中主动发送。
             strongSelf.wsTask = nil;
             @try {
-                [probedTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeAbnormalClosure reason:nil];
-            } @catch (__unused NSException *ex) {}
+                [probedTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeGoingAway reason:nil];
+            } @catch (NSException *ex) {
+                NSLog(@"probeLiveness: cancelWithCloseCode threw %@ (name=%@ reason=%@); task 可能未被取消，将回退依赖 handleWSDisconnectWithError 的 session invalidate",
+                      ex, ex.name, ex.reason);
+            }
             NSError *err = [NSError errorWithDomain:@"WKLivenessProbeTimeout" code:408 userInfo:@{
                 NSLocalizedDescriptionKey: @"前台 liveness probe 未收到 pong，判定假在线并强制重连"
             }];

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
@@ -1031,5 +1031,46 @@ didCompleteWithError:(NSError *)error {
     });
 }
 
+- (void)probeLiveness:(NSTimeInterval)timeout complete:(void (^)(BOOL alive, NSError * __nullable))complete {
+    WKConnectStatus status = self.connectStatus;
+
+    // Case A：状态机认为已连接——可能是真在线，也可能是"假在线"（iOS 后台 NSTimer 冻结
+    // 期间服务端已踢连接，本地状态未变）。发一个 ping，若 timeout 内 lastMsgTimeInterval
+    // 未推进（server 没回 pong、也没有别的入站消息），则强制走 handleWSDisconnectWithError:
+    // 触发断开 + backoffReconnect，重连握手成功后 SDK 内部自动跑 syncConversations。
+    if(status == WKConnected) {
+        NSTimeInterval baseline = self.lastMsgTimeInterval;
+        [self sendPing];
+        __weak typeof(self) weakSelf = self;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if(!strongSelf) { return; }
+            if(strongSelf.lastMsgTimeInterval > baseline) {
+                // 收到 pong 或其他入站消息，连接活着
+                if(complete) { complete(YES, nil); }
+                return;
+            }
+            NSError *err = [NSError errorWithDomain:@"WKLivenessProbeTimeout" code:408 userInfo:@{
+                NSLocalizedDescriptionKey: @"前台 liveness probe 未收到 pong，判定假在线并强制重连"
+            }];
+            NSLog(@"probeLiveness: no pong within %.1fs, forcing reconnect (前台假在线)", timeout);
+            [strongSelf handleWSDisconnectWithError:err];
+            if(complete) { complete(NO, err); }
+        });
+        return;
+    }
+
+    // Case B：握手 / 离线拉取 in flight，SDK 会自然完成，不打扰——避免 teardown 正在拉取
+    // 的 WebSocket 造成 status flapping / 双 sync。
+    if(status == WKConnecting || status == WKPullingOffline) {
+        if(complete) { complete(NO, nil); }
+        return;
+    }
+
+    // Case C：WKDisconnected / WKNoConnect / 其他——直接 connect。
+    [self connect];
+    if(complete) { complete(NO, nil); }
+}
+
 
 @end

--- a/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
+++ b/Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.m
@@ -1032,30 +1032,61 @@ didCompleteWithError:(NSError *)error {
 }
 
 - (void)probeLiveness:(NSTimeInterval)timeout complete:(void (^)(BOOL alive, NSError * __nullable))complete {
+    // 契约：complete 回调统一 hop 到 main queue，调用方可以放心访问 UI 状态。
+    void (^finish)(BOOL, NSError * _Nullable) = ^(BOOL alive, NSError * _Nullable err) {
+        if(!complete) { return; }
+        if([NSThread isMainThread]) {
+            complete(alive, err);
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                complete(alive, err);
+            });
+        }
+    };
+
     WKConnectStatus status = self.connectStatus;
 
     // Case A：状态机认为已连接——可能是真在线，也可能是"假在线"（iOS 后台 NSTimer 冻结
     // 期间服务端已踢连接，本地状态未变）。发一个 ping，若 timeout 内 lastMsgTimeInterval
-    // 未推进（server 没回 pong、也没有别的入站消息），则强制走 handleWSDisconnectWithError:
+    // 未推进（server 没回 pong、也没有别的入站消息），且 socket 仍是被 probe 的那一条 &
+    // 状态仍是 WKConnected，则显式 cancel 该 wsTask 并走 handleWSDisconnectWithError:
     // 触发断开 + backoffReconnect，重连握手成功后 SDK 内部自动跑 syncConversations。
     if(status == WKConnected) {
         NSTimeInterval baseline = self.lastMsgTimeInterval;
+        NSURLSessionWebSocketTask *probedTask = self.wsTask; // snapshot：timeout 内可能已被并发 reconnect 替换
         [self sendPing];
         __weak typeof(self) weakSelf = self;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if(!strongSelf) { return; }
+            // 收到 pong 或其他入站消息 → 连接活着
             if(strongSelf.lastMsgTimeInterval > baseline) {
-                // 收到 pong 或其他入站消息，连接活着
-                if(complete) { complete(YES, nil); }
+                finish(YES, nil);
                 return;
             }
+            // 与 probe 开始时相比，socket 已被并发 reconnect 替换 或 状态已不是 WKConnected：
+            // 说明另一个生命周期在跑（例如 didCompleteWithError: 已经触发了 handleWSDisconnect
+            // + backoffReconnect），不要动它，让那条路径自然收敛，避免二次 backoff。
+            if(strongSelf.wsTask != probedTask || strongSelf.connectStatus != WKConnected) {
+                finish(NO, nil);
+                return;
+            }
+            // 仍是同一条 socket 且仍认为 WKConnected → 判定假在线。
+            // 先显式 cancel 旧 task（handleWSDisconnectWithError: 只 nil 引用不发 close frame，
+            // 会留下 detached socket / session leak，短时间内同一 deviceId 可能双连接）。
+            // 顺序参考 teardownWS: 先把 self.wsTask 置 nil，再 cancel，让延迟的
+            // didClose:/didCompleteWithError: 走 `task != self.wsTask` 早返，不会重复走
+            // handleWSDisconnect（幂等）。
+            strongSelf.wsTask = nil;
+            @try {
+                [probedTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeAbnormalClosure reason:nil];
+            } @catch (__unused NSException *ex) {}
             NSError *err = [NSError errorWithDomain:@"WKLivenessProbeTimeout" code:408 userInfo:@{
                 NSLocalizedDescriptionKey: @"前台 liveness probe 未收到 pong，判定假在线并强制重连"
             }];
             NSLog(@"probeLiveness: no pong within %.1fs, forcing reconnect (前台假在线)", timeout);
             [strongSelf handleWSDisconnectWithError:err];
-            if(complete) { complete(NO, err); }
+            finish(NO, err);
         });
         return;
     }
@@ -1063,13 +1094,13 @@ didCompleteWithError:(NSError *)error {
     // Case B：握手 / 离线拉取 in flight，SDK 会自然完成，不打扰——避免 teardown 正在拉取
     // 的 WebSocket 造成 status flapping / 双 sync。
     if(status == WKConnecting || status == WKPullingOffline) {
-        if(complete) { complete(NO, nil); }
+        finish(NO, nil);
         return;
     }
 
     // Case C：WKDisconnected / WKNoConnect / 其他——直接 connect。
     [self connect];
-    if(complete) { complete(NO, nil); }
+    finish(NO, nil);
 }
 
 


### PR DESCRIPTION
## Summary

**v3 (根据 reviewer 复审 P1 意见再返工)**

reviewer 在 v2 (`5c81d0e1`) 上指出两条新 P1 blocking + 若干非阻塞项。本次全部处理（除明确留 follow-up 的两条）。

## v3 修改要点

### P1 修复

**1. timeout block 加并发 guard（reviewer P1 #1）**
`probeLiveness:` 在 probe 开始时 snapshot `probedTask = self.wsTask`。timeout 到期时先按顺序核查：
- `lastMsgTimeInterval > baseline` → 收到 pong / 其他入站消息 → 连接活着，`finish(YES,nil)`
- `wsTask != probedTask || connectStatus != WKConnected` → 并发路径（如 `didCompleteWithError:` 已触发 `handleWSDisconnect` + `backoffReconnect`）已接管，不打断，`finish(NO,nil)`
- 只有以上两条都不成立才判定假在线，走 destructive 路径

避免 v2 那种"2s 内已经重连、timeout 回调再把新 WKConnecting 打断"的二次 backoff。

**2. 显式 cancel wsTask（reviewer P1 #2）**
destructive 路径参考 `teardownWS` 的顺序：
```objc
strongSelf.wsTask = nil;
[probedTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeAbnormalClosure reason:nil];
[strongSelf handleWSDisconnectWithError:err];
```
先 nil、再 cancel：延迟的 `didClose:` / `didCompleteWithError:` 走 `task != self.wsTask` 幂等早返；不会 double-invoke `handleWSDisconnect`。`cancelWithCloseCode:` 发出 WS close frame 主动关，不再靠 `finishTasksAndInvalidate` 的"等待任务结束"模式（后者可能长期挂着 detached socket，短时间内同 deviceId 双连接）。

### Non-blocking 同步处理

**3. 防抖时钟改 sleep-inclusive（reviewer 建议 #1）**
`CACurrentMediaTime()` 底层是 `CLOCK_UPTIME_RAW`，锁屏/睡眠期间不推进。长锁屏后 `now - lastWakeupAt` 可能仍 < 5s 抑制探测。改用 `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)`：sleep-inclusive，也避开原始的 wall-clock 回拨问题。属性类型 `CFTimeInterval lastWakeupAt` → `uint64_t lastWakeupAtNs`。

**4. probeLiveness: 回调线程契约（reviewer 建议 #3）**
新增 `finish(alive, err)` 局部 block，无论 Case A/B/C 都 hop 到 main queue（若已在 main 则直接调）。header 明确"回调在 main queue"契约。

### 明确留 follow-up 的两条

**5. 2s pong deadline 在刚唤醒蜂窝网络下 false-positive**（reviewer 建议 #2）
可选方案（二次 ping / 更长 timeout / 按 `SCNetworkReachabilityFlags` 自适应）都是独立话题，本 PR 保留 2s。若真机 acceptance 8 复现误判可以专门开一个 loop。

**6. `backoffReconnect` cap 配置为 `60 * 1000` 秒 (~16.7h)**（reviewer 建议 #4）
是 pre-existing bug（`WKConnectionManager.m:115`），与本 PR 正交。本 PR 不改。

## Changes

- `Modules/WuKongIMiOSSDK/WuKongIMSDK/Classes/manager/WKConnectionManager.h` / `.m`
  - `probeLiveness:complete:` 增加并发 guard + 显式 cancel + main queue 契约
  - `wakeup:` 完全未动
- `Modules/WuKongBase/WuKongBase/Classes/WKApp.m`
  - `#import <QuartzCore/QuartzCore.h>` → `#import <time.h>`
  - 私有属性 `lastWakeupAt` (`CFTimeInterval`) → `lastWakeupAtNs` (`uint64_t`)
  - `appDidBecomeActive:` 用 `clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)`

## timeout 路径的三档决策（新）

| timeout 时状态 | 判定 | 动作 |
|---|---|---|
| `lastMsgTimeInterval > baseline` | 真在线 | `finish(YES, nil)` |
| `wsTask != probedTask` 或 `connectStatus != WKConnected` | 并发路径接管 | `finish(NO, nil)`（让并发路径收敛） |
| 以上都不满足 | 假在线 | `wsTask=nil` → `cancel(oldTask)` → `handleWSDisconnectWithError:` → `finish(NO, err)` |

## Acceptance self-check（更新）

- [x] 1. `appDidBecomeActive` 无条件调用 SDK `probeLiveness:`
- [x] 2. timeout 参数 2 秒
- [x] 3. 5 秒防抖，改用 `CLOCK_MONOTONIC_RAW`（sleep-inclusive）
- [~] 4. 原写"SDK 只读不写"，reviewer 认可 additive 扩展；本 PR SDK 侧只新增 `probeLiveness:` + 改它自己的实现，`wakeup:` / `connect` / `handleWSDisconnectWithError:` 现有 API 现签名 & 语义零变化
- [x] 5. 不改 `Octo/AppDelegate.m`
- [x] 6. 不引入新的 `POST /conversation/sync`
- [x] 7. 防抖时间戳存 `WKApp` 私有属性
- [ ] 8. 手动测试用例（真机复现验证）：iOS 后台 5+ 分钟，web 端发消息，回前台 10 秒内会话列表更新
- [ ] 9. 快速切换回归：5 秒内切 3 次只应触发 1 次 probe
- [x] 10. commit message 不带 AI 标记

## Reviewer 项处理清单

| Reviewer 项 | 状态 |
|---|---|
| 🔴 P1-1 timeout 缺 socket/state 再核查 | ✅ 三档 guard：alive → 并发接管 → destructive |
| 🔴 P1-2 没显式 cancel wsTask | ✅ 参考 teardownWS 顺序：nil → cancel → handleWSDisconnect |
| 🟡 CACurrentMediaTime 睡眠不推进 | ✅ 改 CLOCK_MONOTONIC_RAW |
| 🟡 2s deadline 蜂窝 false-positive | ⏳ 留 follow-up |
| 🟡 callback sync/async 不一致 | ✅ 统一 hop main queue + header 契约 |
| 🟡 backoff cap 60*1000 单位错 | ⏳ 留 follow-up（pre-existing bug，正交） |
| 🔵 Acceptance 8/9 真机复现 | ⏳ 待 iOS-QA |

Closes #88
Related: WS-212
